### PR TITLE
Don't launch heapster service by default

### DIFF
--- a/cloud_configs/master.yaml
+++ b/cloud_configs/master.yaml
@@ -54,6 +54,15 @@ write_files:
     sed -e 's,$SERVICE_IP,$SERVICE_PUBLIC_IP,g' \
         -i -- ./guestbook/frontend-service.json
     /opt/bin/kubectl --server=http://$MASTER_IP:8080 create -f ./guestbook/
+- path: /opt/bin/kraken-create-heapster.sh
+  owner: root
+  content: |
+    #! /usr/bin/bash
+    set -x
+    cd /opt/bin/kraken-services
+    sed -e 's,$HEAPSTER_PUBLIC_IP,$NODE_01_PRIVATE_IP,g' \
+        -i -- ./heapster/*.{json,yaml}
+    /opt/bin/kubectl --server=http://$MASTER_IP:8080 create -f ./heapster/
 - path: /opt/bin/kraken-create-influxdb-grafana.sh
   owner: root
   content: |
@@ -63,7 +72,6 @@ write_files:
     sed -e 's,$INFLUXDB_EXTERNAL_HOST,$NODE_01_PUBLIC_IP,g' \
         -e 's,$INFLUXDB_PUBLIC_IP,$NODE_01_PRIVATE_IP,g' \
         -e 's,$GRAFANA_PUBLIC_IP,$NODE_01_PRIVATE_IP,g' \
-        -e 's,$HEAPSTER_PUBLIC_IP,$NODE_01_PRIVATE_IP,g' \
         -i -- ./influxdb-grafana/*.{json,yaml}
     /opt/bin/kubectl --server=http://$MASTER_IP:8080 create -f ./influxdb-grafana/
 - path: /opt/bin/wait4skydns.sh
@@ -312,7 +320,7 @@ coreos:
         Description=Kubernetes guestbook example
         Requires=kraken-create-skydns.service
         After=kraken-create-skydns.service
-        
+
         [Service]
         TimeoutStartSec=0
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kraken-create-guestbook.sh
@@ -339,11 +347,27 @@ coreos:
         Description=Kubernetes influxdb-grafana service
         Requires=wait4skydns.service
         After=wait4skydns.service
-        
+        ConditionNull=$KRAKEN_SERVICES_INFLUXDB_GRAFANA_ENABLED
+
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/usr/bin/chmod +x /opt/bin/kraken-create-influxdb-grafana.sh
         ExecStart=/usr/bin/bash /opt/bin/kraken-create-influxdb-grafana.sh
+        RemainAfterExit=true
+        Type=oneshot
+    - name: kraken-create-heapster.service
+      command: start
+      content: |
+        [Unit]
+        Description=Kubernetes heapster service
+        Requires=wait4skydns.service
+        After=wait4skydns.service
+        ConditionNull=$KRAKEN_SERVICES_HEAPSTER_ENABLED
+
+        [Service]
+        TimeoutStartSec=0
+        ExecStartPre=-/usr/bin/chmod +x /opt/bin/kraken-create-heapster.sh
+        ExecStart=/usr/bin/bash /opt/bin/kraken-create-heapster.sh
         RemainAfterExit=true
         Type=oneshot
   update:

--- a/features/services_aws.feature
+++ b/features/services_aws.feature
@@ -10,10 +10,9 @@ Feature: Make sure we have the correct kubernetes services
     And the output should eventually match:
       """
       .*
+      grafana.*
+      influxdb.*
       kube-dns.*
       kubernetes.*
       kubernetes-ro.*
-      grafana.*
-      heapster.*
-      influxdb.*
       """

--- a/features/services_local.feature
+++ b/features/services_local.feature
@@ -10,10 +10,9 @@ Feature: Make sure we have the correct kubernetes services
     And the output should eventually match:
       """
       .*
+      grafana.*
+      influxdb.*
       kube-dns.*
       kubernetes.*
       kubernetes-ro.*
-      grafana.*
-      heapster.*
-      influxdb.*
       """

--- a/kubernetes/Vagrantfile
+++ b/kubernetes/Vagrantfile
@@ -190,6 +190,9 @@ def build_coreos_userdata(host_number)
     '$SERVICE_PUBLIC_IP' => proxy_cluster_ip,
     '$KRAKEN_SERVICES_BRANCH' => cluster_services['branch'],
     '$KRAKEN_SERVICES_REPO' => cluster_services['repo'],
+    # TODO: parse out from cluster.services
+    '$KRAKEN_SERVICES_INFLUXDB_GRAFANA_ENABLED' => 'true',
+    '$KRAKEN_SERVICES_HEAPSTER_ENABLED' => 'false',
     '$RUN_EXAMPLES' => example_state,
     '$DOCKER_CACHE' => etcd_cluster_ip,
     '$NODE_01_PRIVATE_IP' => proxy_cluster_ip,

--- a/kubernetes/kraken
+++ b/kubernetes/kraken
@@ -101,8 +101,8 @@ command :test do |test_command|
     unless $?.success?
       system("ERROR: tests failed, displaying journalctl output from master")
       blacklist_regexes = %w(handlers.go motd OpenSSH sshd)
-      blacklist_grep_cmd = blacklist_regexes.map { |x| "grep -v #{x}" }.join(" \\| ")
-      system("kraken #{cluster} ssh master -c \\' journalctl --no-pager \\| #{blacklist_grep_cmd} \\'")
+      blacklist_grep_cmd = blacklist_regexes.map { |x| "grep -v #{x}" }.join(" \| ")
+      run("#{cluster} ssh master -c \' journalctl --no-pager \| #{blacklist_grep_cmd} \'".split(' '))
     end
   end
 end

--- a/kubernetes/kraken
+++ b/kubernetes/kraken
@@ -49,16 +49,18 @@ CLUSTERS.each do |cluster, cluster_path|
       cluster_command.switch :unittest, :negatable => false, :default_value => false
     end
     cluster_command.action do |global_options,options,args|
-      command_str = "KRAKEN_CLUSTER='#{cluster}' "\
-                    "VAGRANT_DOTFILE_PATH='#{cluster_path}' "\
-                    "VAGRANT_CWD='#{__dir__}'"
+      env_vars = "KRAKEN_CLUSTER='#{cluster}' "\
+        "VAGRANT_DOTFILE_PATH='#{cluster_path}' "\
+        "VAGRANT_CWD='#{__dir__}'"
 
       if options[:unittest]
-        command_str += " KRAKEN_UNITTEST=true"
+        env_vars += " KRAKEN_UNITTEST=true"
       end
 
-      puts "# executing: #{command_str} vagrant #{args.join(' ')}"
-      exec "#{command_str} vagrant #{args.join(' ')}"
+      command_str = "#{env_vars} vagrant #{args.join(' ')}"
+
+      puts "# executing: #{command_str}"
+      system(command_str)
     end
   end
 end
@@ -77,20 +79,24 @@ command :test do |test_command|
     raise "#{settings_yaml} not found. You need to create it!" unless File.exist?(settings_yaml)
 
     settings = YAML.load_file(settings_yaml)
-    command_str = "kubectl config set-cluster #{args[0]} --server=http://"
-    if args[0] == 'aws'
-      aws_master = settings['aws']['masterHostName'] || settings['aws']['masterPublicIp']
-      command_str += "#{aws_master}:8080 "
-    else
-      network = settings['cluster']['network'] || '172.16.1.0/24'
-      ip = IPAddr.new(network).to_s.chomp("0") + "#{2+100}"
-      command_str += "#{ip}:8080 "
-    end
+    kube_master = case args[0]
+                  when 'aws'
+                    settings['aws']['masterHostName'] || settings['aws']['masterPublicIp']
+                  else
+                    network = settings['cluster']['network'] || '172.16.1.0/24'
+                    IPAddr.new(network).to_s.chomp("0") + "#{2+100}"
+                  end
 
-    command_str += "--api-version=#{settings['cluster']['apiVersion']}"
-    puts 'Creating kubeconfig file and running tests'
-    exec command_str + '; ' + "cucumber #{File.join(__dir__, '..', 'features', "*_#{args[0]}.feature")}"
+    kube_set_cluster_cmd = "kubectl config set-cluster #{args[0]}"\
+      " --server=http://#{kube_master}:8080"\
+      " --api-version=#{settings['cluster']['apiVersion']}"
 
+    cucumber_cmd = "cucumber #{File.join(__dir__, '..', 'features', "*_#{args[0]}.feature")}"
+
+    command_str = "#{kube_set_cluster_cmd}; #{cucumber_cmd}"
+
+    puts "# executing: #{command_str}"
+    system(command_str)
   end
 end
 

--- a/kubernetes/kraken
+++ b/kubernetes/kraken
@@ -75,11 +75,12 @@ long_desc "Run cucumber tests on a cluster. For example:
 "
 command :test do |test_command|
   test_command.action do |global_options,options,args|
-    settings_yaml = File.join(CLUSTERS_PATH, args[0], 'settings.yaml')
+    cluster = args[0]
+    settings_yaml = File.join(CLUSTERS_PATH, cluster, 'settings.yaml')
     raise "#{settings_yaml} not found. You need to create it!" unless File.exist?(settings_yaml)
 
     settings = YAML.load_file(settings_yaml)
-    kube_master = case args[0]
+    kube_master = case cluster
                   when 'aws'
                     settings['aws']['masterHostName'] || settings['aws']['masterPublicIp']
                   else
@@ -87,16 +88,22 @@ command :test do |test_command|
                     IPAddr.new(network).to_s.chomp("0") + "#{2+100}"
                   end
 
-    kube_set_cluster_cmd = "kubectl config set-cluster #{args[0]}"\
+    kube_set_cluster_cmd = "kubectl config set-cluster #{cluster}"\
       " --server=http://#{kube_master}:8080"\
       " --api-version=#{settings['cluster']['apiVersion']}"
 
-    cucumber_cmd = "cucumber #{File.join(__dir__, '..', 'features', "*_#{args[0]}.feature")}"
+    cucumber_cmd = "cucumber #{File.join(__dir__, '..', 'features', "*_#{cluster}.feature")}"
 
     command_str = "#{kube_set_cluster_cmd}; #{cucumber_cmd}"
 
     puts "# executing: #{command_str}"
     system(command_str)
+    unless $?.success?
+      system("ERROR: tests failed, displaying journalctl output from master")
+      blacklist_regexes = %w(handlers.go motd OpenSSH sshd)
+      blacklist_grep_cmd = blacklist_regexes.map { |x| "grep -v #{x}" }.join(" \\| ")
+      system("kraken #{cluster} ssh master -c \\' journalctl --no-pager \\| #{blacklist_grep_cmd} \\'")
+    end
   end
 end
 


### PR DESCRIPTION
Use the ConditionNull field to use a constant substituted in by
kraken's Vagrantfile.  Can later be pulled in from settings.yaml

This won't actually defer launching heapster until kraken-services has it broken out into another subdir