### PR TITLE
Generate kraken-node=hostname labels for each node

### DIFF
--- a/cloud_configs/master.yaml
+++ b/cloud_configs/master.yaml
@@ -187,6 +187,19 @@ coreos:
             Environment=DOCKER_OPTS='--registry-mirror=http://$DOCKER_CACHE:5000'
     - name: fleet.service
       command: start
+    - name: install-kubectl.service
+      command: start
+      content: |
+        [Unit]
+        Description=Install kubectl client tool
+        Requires=network-online.target
+        After=network-online.target
+
+        [Service]
+        ExecStart=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl
+        ExecStart=/usr/bin/chmod +x /opt/bin/kubectl
+        Type=oneshot
+        RemainAfterExit=true
     - name: kube-apiserver.service
       command: start
       content: |
@@ -294,9 +307,7 @@ coreos:
 
         [Service]
         TimeoutStartSec=0
-        ExecStartPre=-/usr/bin/bash /opt/bin/download-kraken-services.sh
-        ExecStartPre=/usr/bin/cp /opt/bin/kraken-services/bin/linux/kubectl /opt/bin/
-        ExecStart=/usr/bin/chmod +x /opt/bin/kubectl
+        ExecStart=/usr/bin/bash /opt/bin/download-kraken-services.sh
         RemainAfterExit=true
         Type=oneshot
     - name: kraken-create-skydns.service

--- a/cloud_configs/node.yaml
+++ b/cloud_configs/node.yaml
@@ -17,6 +17,11 @@ write_files:
   content: |
     #! /usr/bin/bash
     until curl http://$MASTER_IP:8080; do sleep 2; done
+- path: /opt/bin/wait4node.sh
+  owner: root
+  content: |
+    #! /usr/bin/bash
+    until /opt/bin/kubectl --server=$MASTER_IP:8080 get nodes | grep -q $private_ipv4; do sleep 2; done
 coreos:
   etcd2:
     proxy: on
@@ -185,6 +190,32 @@ coreos:
         --v=$KUBERNETES_VERBOSITY
         Restart=always
         RestartSec=10
+    - name: wait4node.service
+      command: start
+      content: |
+        [Unit]
+        Description=Wait for node to register with kube-apiserver
+        Requires=kube-kubelet.service
+        After=kube-kubelet.service
+
+        [Service]
+        ExecStartPre=/usr/bin/chmod +x /opt/bin/wait4node.sh
+        ExecStart=/usr/bin/bash /opt/bin/wait4node.sh
+        RemainAfterExit=true
+        Type=oneshot
+    - name: run-kubectl-label-node.service
+      command: start
+      content: |
+        [Unit]
+        Description=Try labeling ourselves
+        Requires=wait4node.service
+        After=wait4node.service
+
+        [Service]
+        ExecStart=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl
+        ExecStart=/opt/bin/kubectl --server=$MASTER_IP:8080 label nodes $private_ipv4 kraken-node=$HOSTNAME
+        Type=oneshot
+        RemainAfterExit=true
   update:
     group: alpha
     reboot-strategy: $REBOOT_STRATEGY

--- a/cloud_configs/node.yaml
+++ b/cloud_configs/node.yaml
@@ -123,6 +123,19 @@ coreos:
         ExecStart=/usr/bin/bash /opt/bin/wait4apiserver.sh
         RemainAfterExit=true
         Type=oneshot
+    - name: install-kubectl.service
+      command: start
+      content: |
+        [Unit]
+        Description=Install kubectl client tool
+        Requires=network-online.target
+        After=network-online.target
+
+        [Service]
+        ExecStart=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl
+        ExecStart=/usr/bin/chmod +x /opt/bin/kubectl
+        Type=oneshot
+        RemainAfterExit=true
     - name: kube-proxy.service
       command: start
       content: |

--- a/kubernetes/Vagrantfile
+++ b/kubernetes/Vagrantfile
@@ -187,6 +187,7 @@ def build_coreos_userdata(host_number)
     '$REBOOT_STRATEGY' => settings['coreos']['rebootStrategy'] || 'off',
     '$CLOUD_PROVIDER' => 'vagrant',
     '$DNS_DOMAIN' => 'kubernetes.local',
+    '$HOSTNAME' => node_info[:hostname],
     '$SERVICE_PUBLIC_IP' => proxy_cluster_ip,
     '$KRAKEN_SERVICES_BRANCH' => cluster_services['branch'],
     '$KRAKEN_SERVICES_REPO' => cluster_services['repo'],

--- a/kubernetes/clusters/aws/Vagrantfile
+++ b/kubernetes/clusters/aws/Vagrantfile
@@ -193,6 +193,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         when 'etcd'
           aws.instance_type = aws_settings['instanceTypeEtcd'] unless aws_settings['instanceTypeEtcd'].nil?
         when 'node-01'
+          aws.instance_type = aws_settings['instanceTypeNode01'] unless aws_settings['instanceTypeNode01'].nil?
           aws.elastic_ip = aws_settings['nodePublicIp'] if aws_settings['nodePublicIp']
           if aws_settings['proxyHostName']
             override.route53.hosted_zone_id = aws_settings['hostedZoneId']
@@ -202,7 +203,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
         # join to ELB if, specified
         if node_info[:hostname].start_with?('node-')
-          aws.instance_type = aws_settings['instanceTypeNode'] unless aws_settings['instanceTypeNode'].nil?
+          unless node_info[:hostname] == 'node-01'
+            aws.instance_type = aws_settings['instanceTypeNode'] unless aws_settings['instanceTypeNode'].nil?
+          end
           aws.elb = aws_settings['elb']['name'] unless aws_settings['elb'].nil?
         end
 


### PR DESCRIPTION
Nodes do it themselves via cloud-init driven systemd units

Hostname is passed in from kraken as env var substitution to cloud configs

Pods can then be scheduled to nodes using the `nodeSelector` field