### PR TITLE
Ensure coreos version is respected

### DIFF
--- a/kubernetes/Vagrantfile
+++ b/kubernetes/Vagrantfile
@@ -99,7 +99,7 @@ def coreos_boxname
 end
 
 def coreos_url
-  "http://#{coreos_channel}.release.core-os.net/amd64-usr/current"
+  "http://#{coreos_channel}.release.core-os.net/amd64-usr"
 end
 
 def coreos_release
@@ -107,7 +107,7 @@ def coreos_release
   version = settings['coreos']['version'] || 'latest'
   return version unless version == 'latest'
 
-  version_url = "#{coreos_url}/version.txt"
+  version_url = "#{coreos_url}/current/version.txt"
   open(version_url).read().scan(/COREOS_VERSION=.*/)[0].split('=')[1]
 end
 

--- a/kubernetes/clusters/aws/Vagrantfile
+++ b/kubernetes/clusters/aws/Vagrantfile
@@ -139,7 +139,7 @@ coreos_ami = {
 
 if aws_settings['amiId'] == 'latest'
   aws_ami_url = coreos_ami[aws_settings['regionId']]
-  coreos_ami_url = "#{coreos_url}/current/#{aws_ami_url}"
+  coreos_ami_url = "#{coreos_url}/#{coreos_release}/#{aws_ami_url}"
   aws_settings['amiId'] = open(coreos_ami_url).read().chomp
 end
 

--- a/kubernetes/clusters/aws/Vagrantfile
+++ b/kubernetes/clusters/aws/Vagrantfile
@@ -139,7 +139,7 @@ coreos_ami = {
 
 if aws_settings['amiId'] == 'latest'
   aws_ami_url = coreos_ami[aws_settings['regionId']]
-  coreos_ami_url = "#{coreos_url}/#{aws_ami_url}"
+  coreos_ami_url = "#{coreos_url}/current/#{aws_ami_url}"
   aws_settings['amiId'] = open(coreos_ami_url).read().chomp
 end
 

--- a/kubernetes/clusters/local/Vagrantfile
+++ b/kubernetes/clusters/local/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = coreos_boxname
   config.vm.box_version = "= #{coreos_release}"
-  config.vm.box_url = "#{coreos_url}/coreos_production_vagrant.json"
+  config.vm.box_url = "#{coreos_url}/#{coreos_release}/coreos_production_vagrant.json"
 
   config.trigger.after [:up, :resume] do
     info "making sure ssh agent has the default vagrant key..."


### PR DESCRIPTION
For some reason the aws and local clusters were defaulting to trying to pull from the 'current' release instead of whatever version was actually specified.  Now they'll respect the value in coreos.version