### PR TITLE
Default to v1 api in sample settings

### DIFF
--- a/kubernetes/clusters/aws/settings.sample.yaml
+++ b/kubernetes/clusters/aws/settings.sample.yaml
@@ -48,7 +48,7 @@ aws:
 cluster:                     
   kubernetesVersion: stable                                  #default = stable
   nodes: 3                                                   #default = 3
-  apiVersion: v1beta3                                        #default = v1beta3
+  apiVersion: v1                                             #default = v1
   network:                                                   #required, CIDR of aws.subnetId
   guestbook: 
     run: false                                               #default = false

--- a/kubernetes/clusters/local/settings.sample.yaml
+++ b/kubernetes/clusters/local/settings.sample.yaml
@@ -17,7 +17,7 @@ vmSettings:
 cluster:                     
   kubernetesVersion: stable                                  #default = stable
   nodes: 2                                                   #default = 3
-  apiVersion: v1beta3                                        #default = v1beta3
+  apiVersion: v1                                             #default = v1
   network: 172.16.1.0/24                                     #default = 172.16.1.0/24
   guestbook: 
     run: false                                               #default = false


### PR DESCRIPTION
This is mostly just to trigger a kraken-ci build and make sure the latest kraken-services resources and docker images all still check out.