### PR TITLE
Namespace Workaround

### DIFF
--- a/ansible/roles/kubernetes/tasks/kraken-services.yaml
+++ b/ansible/roles/kubernetes/tasks/kraken-services.yaml
@@ -30,6 +30,11 @@
             dest=/opt/bin/kraken-create.sh
   sudo: yes
 
+- name: Create kraken-create-only script
+  template: src=kraken-create-only.sh.ansible
+            dest=/opt/bin/kraken-create-only.sh
+  sudo: yes
+
 - name: Create kraken-create-services script
   template: src=kraken-create-services.sh.ansible
             dest=/opt/bin/kraken-create-services.sh

--- a/ansible/roles/kubernetes/templates/kraken-create-only.sh.ansible
+++ b/ansible/roles/kubernetes/templates/kraken-create-only.sh.ansible
@@ -1,0 +1,15 @@
+#! /usr/bin/bash
+#
+# special "no delete" version for items that take too long to delete
+# NOTE: for now, just assume NO change in this type of file... only additional entris in dir.  So 
+# NOTE: we shortcut and do NOT wait for delete to complete.
+#
+# the issue here is with namespace type of deletions.  The delete command only starts the delete.  The namespace 
+# will not be fully deleted before the command returns.
+#
+# TODO: future deletion complete check needed
+set -x
+cd /opt/bin/kraken-services-rendered
+for dir in $*; do
+  /opt/bin/kubectl --server=http://{{master_private_ip}}:8080 create -f ./$dir/
+done

--- a/ansible/roles/kubernetes/templates/kraken-create-services.service.ansible
+++ b/ansible/roles/kubernetes/templates/kraken-create-services.service.ansible
@@ -6,5 +6,6 @@ Requires=kraken-render.service
 RestartSec=5
 Restart=always
 ExecStartPre=-/usr/bin/chmod +x /opt/bin/kraken-create.sh
+ExecStartPre=-/usr/bin/chmod +x /opt/bin/kraken-create-only.sh
 ExecStartPre=-/usr/bin/chmod +x /opt/bin/kraken-create-services.sh
 ExecStart=/usr/bin/bash /opt/bin/kraken-create-services.sh

--- a/ansible/roles/kubernetes/templates/kraken-create-services.sh.ansible
+++ b/ansible/roles/kubernetes/templates/kraken-create-services.sh.ansible
@@ -4,7 +4,8 @@ set -x
 services_created=false
 while true; do
   if ! $services_created; then
-    /opt/bin/kraken-create.sh namespaces skydns {{kraken_services_dirs}} && services_created=true
+    /opt/bin/kraken-create-only.sh namespaces 
+    /opt/bin/kraken-create.sh skydns {{kraken_services_dirs}} && services_created=true
     sleep 5
   else
     sleep 900

--- a/features/services_aws.feature
+++ b/features/services_aws.feature
@@ -4,7 +4,16 @@ Feature: Make sure we have the correct kubernetes services
   As kraken developer 
   I should be able to run these scenario and see the correct exit code and services output
 
-  Scenario: Getting services
+  Scenario: Getting kube-system services
+    When I run `kubectl --cluster=aws get services --namespace=kube-system`
+    Then the exit status should eventually be 0
+    And the output should eventually match:
+      """
+      .*
+      kube-dns.*
+      """
+
+  Scenario: Getting default services
     When I run `kubectl --cluster=aws get services`
     Then the exit status should eventually be 0
     And the output should eventually match:
@@ -13,7 +22,6 @@ Feature: Make sure we have the correct kubernetes services
       framework.*
       grafana.*
       influxdb.*
-      kube-dns.*
       kube-ui.*
       kubernetes.*
       load-generator-master.*

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -229,7 +229,9 @@ variable "kube_proxy_v" {
   description = "kubernetes proxy verbosity"
 }
 variable "kraken_services_dirs" {
-  default = "namespaces influxdb-grafana kube-ui loadtest podpincher skydns prometheus"
+  # NOTE: DO NOT INCLUDE namespaces here.  It is hard coded into the scripts
+  # NOTE: skydns is also hardcoded into the scripts
+  default = "influxdb-grafana kube-ui loadtest podpincher prometheus"
   description = "Kraken services folders under kraken repo to deploy kubernetes services from."
 }
 variable "logentries_token" {


### PR DESCRIPTION
KRAK-133.   

Namespace delete takes much longer time than the delete statement.  This leads to timing issues as the namespace may be deleted after the delete command but before a check for the namespace.  e.g. this was preventing skydns finding the namespace.

For now, only create namespace.  Changes to a namespace occur via a new file, not a change to the current file.  

If this is an issue, then add delete completion check to the namespace create command.

ALSO, namespace and skydns were being started twice by default... once in the hardcode in the scripts and one more time in the user's start list.
