### PR TITLE
Add Allowed IPs to Cert Key Gen

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yaml
+++ b/ansible/roles/kubernetes/defaults/main.yaml
@@ -44,6 +44,7 @@ kube_controller_manager:
   pvclaimbinder-sync-period: 10s
   register-retry-count: 10
   resource-quota-sync-period: 20s
+  root-ca-file: /srv/kubernetes/ca.crt
   service-account-private-key-file: /srv/kubernetes/server.key
   service-sync-period: 5m0s
   v: 1

--- a/generate-cert/make-cert-tokens.sh
+++ b/generate-cert/make-cert-tokens.sh
@@ -19,8 +19,8 @@ my_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cur_dir=$( pwd )
 echo "CUR: ${cur_dir}"
 
-if [ $# -lt 1 -o  $# -gt 2 ]; then
-    echo "Usage $0 <Master IP> [Cert Directory]"
+if [ $# -lt 1 -o  $# -gt 3 ]; then
+    echo "Usage $0 <Master IP> <DNS IP> [Cert Directory]"
     exit 1
 fi
 #
@@ -28,17 +28,23 @@ fi
 master_ip=$1
 low_ip=${master_ip%.*}.1
 #
-if [ $# -eq 2 ]; then
-    tmp_cert_dir=$2
+#
+dns_ip=$2
+pod_low_ip=${dns_ip%.*}.1
+pod_high_ip=${dns_ip%.*}.255
+#
+#
+if [ $# -eq 3 ]; then
+    tmp_cert_dir=$3
 else
     tmp_cert_dir=$(mktemp -d ${cur_dir}/kube-certs)
 fi
 echo "tmp_cert_dir: ${tmp_cert_dir}"
 CERT_DIR=${CERT_DIR:-${tmp_cert_dir}}
 CERT_GROUP=${CERT_GROUP:-root}
-echo "my_dir: ${my_dir} master: ${master_ip} low: ${low_ip} cert_group: ${CERT_GROUP} cert_dir: ${CERT_DIR}"
+echo "my_dir: ${my_dir} master: ${master_ip} low: ${low_ip} pod: ${pod_low_ip}:${pod_high_ip} cert_group: ${CERT_GROUP} cert_dir: ${CERT_DIR}"
 #
-source ${my_dir}/make-ca-cert.sh ${master_ip} IP:${master_ip},IP:${low_ip},DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster.local
+source ${my_dir}/make-ca-cert.sh ${master_ip} IP:${master_ip},IP:${low_ip},IP:${pod_low_ip},IP:${pod_high_ip},DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster.local
 
 SRV_BASE_DIR=$CERT_DIR
 source "${my_dir}/make-token.sh"

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -213,7 +213,7 @@ resource "aws_s3_bucket" "b" {
   policy = "{\"Version\": \"2012-10-17\", \"Statement\": [ { \"Sid\": \"Stmt1442424671241\", \"Action\": [ \"s3:GetObject\" ], \"Effect\": \"Allow\", \"Resource\": \"arn:aws:s3:::${var.aws_kraken_s3_bucket}-${var.aws_user_prefix}-${var.aws_cluster_prefix}/*\", \"Principal\": \"*\" } ] }"
 }
 resource "execute_command" "kube-cert-gen" {
-  command = "${path.module}/../../generate-cert/make-cert-tokens.sh ${aws_instance.kubernetes_master.private_ip} ${path.module}/kube-cert"
+  command = "${path.module}/../../generate-cert/make-cert-tokens.sh ${aws_instance.kubernetes_master.private_ip} ${var.dns_ip} ${path.module}/kube-cert"
   destroy_command = "rm -rf ${path.module}/kube-cert"
   # kube-certs.tgz
   #


### PR DESCRIPTION
This adds the POD low IP to the cert allowed IPs. 
This corrects the additional error in Network conformance test, and prestop test.

This also contains the previous need to add --root-ca-file to ManagerController.
This corrects the ServiceAccount test for token_mount/ca.crt mount.

After much research. This additional argument is needed so the service accounts mount ca.crt in each of the pods. This also fixes one of the failing conformance test, and one of the issues in 2 other ones.