### PR TITLE
Use drop-in unit to set docker log level via DOCKER_OPTS

### DIFF
--- a/terraform/aws/templates/apiserver.yaml.tpl
+++ b/terraform/aws/templates/apiserver.yaml.tpl
@@ -52,6 +52,12 @@ coreos:
         RemainAfterExit=yes
         ExecStart=/usr/sbin/wipefs -f ${format_docker_storage_mnt}
         ExecStart=/usr/sbin/mkfs.ext4 -F ${format_docker_storage_mnt}
+    - name: docker.service
+      drop-ins:
+        - name: 50-docker-opts.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-level=warn"
     - name: var-lib-docker.mount
       command: start
       content: |

--- a/terraform/aws/templates/etcd.yaml.tpl
+++ b/terraform/aws/templates/etcd.yaml.tpl
@@ -39,6 +39,12 @@ coreos:
         RemainAfterExit=yes
         ExecStart=/usr/sbin/wipefs -f ${format_docker_storage_mnt}
         ExecStart=/usr/sbin/mkfs.ext4 -F ${format_docker_storage_mnt}
+    - name: docker.service
+      drop-ins:
+        - name: 50-docker-opts.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-level=warn"
     - name: var-lib-etcd2.mount
       command: start
       content: |

--- a/terraform/aws/templates/master.yaml.tpl
+++ b/terraform/aws/templates/master.yaml.tpl
@@ -57,6 +57,12 @@ coreos:
         RemainAfterExit=yes
         ExecStart=/usr/sbin/wipefs -f ${format_docker_storage_mnt}
         ExecStart=/usr/sbin/mkfs.ext4 -F ${format_docker_storage_mnt}
+    - name: docker.service
+      drop-ins:
+        - name: 50-docker-opts.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-level=warn"
     - name: var-lib-docker.mount
       command: start
       content: |

--- a/terraform/aws/templates/node.yaml.tpl
+++ b/terraform/aws/templates/node.yaml.tpl
@@ -56,6 +56,12 @@ coreos:
         RemainAfterExit=yes
         ExecStart=/usr/sbin/wipefs -f ${format_docker_storage_mnt}
         ExecStart=/usr/sbin/mkfs.ext4 -F ${format_docker_storage_mnt}
+    - name: docker.service
+      drop-ins:
+        - name: 50-docker-opts.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-level=warn"
     - name: var-lib-docker.mount
       command: start
       content: |

--- a/terraform/local/templates/apiserver.yaml.tpl
+++ b/terraform/local/templates/apiserver.yaml.tpl
@@ -15,6 +15,12 @@ coreos:
     etcd-endpoints: http://${etcd_private_ip}:4001
     interface: $private_ipv4
   units:
+    - name: docker.service
+      drop-ins:
+        - name: 50-docker-opts.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-level=warn"
     - name: docker-tcp.socket
       command: start
       enable: true

--- a/terraform/local/templates/etcd.yaml.tpl
+++ b/terraform/local/templates/etcd.yaml.tpl
@@ -19,6 +19,12 @@ coreos:
       command: start
     - name: etcd2.service
       command: start
+    - name: docker.service
+      drop-ins:
+        - name: 50-docker-opts.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-level=warn"
     - name: systemd-journal-gatewayd.socket
       command: start
       enable: yes

--- a/terraform/local/templates/master.yaml.tpl
+++ b/terraform/local/templates/master.yaml.tpl
@@ -15,6 +15,12 @@ coreos:
     etcd-endpoints: http://${etcd_private_ip}:4001
     interface: $private_ipv4
   units:
+    - name: docker.service
+      drop-ins:
+        - name: 50-docker-opts.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-level=warn"
     - name: docker-tcp.socket
       command: start
       enable: true

--- a/terraform/local/templates/node.yaml.tpl
+++ b/terraform/local/templates/node.yaml.tpl
@@ -15,6 +15,12 @@ coreos:
     etcd-endpoints: http://${etcd_private_ip}:4001
     interface: $private_ipv4
   units:
+    - name: docker.service
+      drop-ins:
+        - name: 50-docker-opts.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-level=warn"
     - name: docker-tcp.socket
       command: start
       enable: true


### PR DESCRIPTION
Followed example in https://coreos.com/os/docs/latest/cloud-config.html

Goal is to free up some io/cpu capacity on nodes