### PR TITLE
Get cadvisor to auto-start on master/etcd

### DIFF
--- a/ansible/roles/kubernetes/templates/cadvisor.service.ansible
+++ b/ansible/roles/kubernetes/templates/cadvisor.service.ansible
@@ -1,12 +1,14 @@
 [Unit]
 Description=Download and run cadvisor
-Requires=early-docker.service
+After=docker.service
+Requires=docker.service
 
 [Service]
 Restart=always
 RestartSec=5
 ExecStartPre=-/usr/bin/docker kill cadvisor
-ExecStartPre=-/usr/bin/docker rm cadvisor
+ExecStartPre=-/usr/bin/docker rm -f cadvisor
+ExecStartPre=-/usr/bin/docker pull cadvisor
 ExecStart=/usr/bin/bash -c \
   "/usr/bin/docker run \
   --name=cadvisor \


### PR DESCRIPTION
Depend on docker.service instead of early-docker.service