### PR TITLE
kubernetes-label unit should restart if its script is changed

### DIFF
--- a/ansible/roles/kubernetes/tasks/node-post.yaml
+++ b/ansible/roles/kubernetes/tasks/node-post.yaml
@@ -4,6 +4,9 @@
   template: src=kubernetes-label.sh.ansible
             dest=/opt/bin/kubernetes-label.sh
   sudo: yes
+  notify:
+    - reload systemd
+    - restart kubernetes-label
 
 - name: Create kubernetes-label
   template: src=kubernetes-label.service.ansible


### PR DESCRIPTION
This appears to be what caused my "scheduler thinks there are no nodes to schedule to" problem.

After an `ansible-playbook` run, I see nodes have their hostname updated and their kubernetes-label script updated to use `node-NNN` instead of `autoscaled`.  I'm guessing somehow this is falling out of sync, and so even though the API is reporting nodes as present, they somehow don't seem valid to scheduler.

This may be worth digging into a bit more on the kubernetes side, seems like changing the hostname on a node shouldn't cause it to go missing in the scheduler's eyes.