### PR TITLE
Use smaller more granular volumes for nodes

### DIFF
--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -390,8 +390,8 @@ resource "template_file" "node_cloudinit_special" {
     master_private_ip = "${aws_instance.kubernetes_master.private_ip}"
     master_public_ip = "${aws_instance.kubernetes_master.public_ip}"
     cluster_proxy_record = "${var.aws_user_prefix}-proxy.${var.aws_cluster_domain}"
-    format_docker_storage_mnt = "${lookup(var.format_docker_storage_mnt, element(split(",", var.aws_storage_type_special), count.index))}"
-    format_kubelet_storage_mnt = "${lookup(var.format_kubelet_storage_mnt, element(split(",", var.aws_storage_type_special), count.index))}"
+    format_docker_storage_mnt = "${lookup(var.format_docker_storage_mnt, element(split(",", var.aws_storage_type_special_docker), count.index))}"
+    format_kubelet_storage_mnt = "${lookup(var.format_kubelet_storage_mnt, element(split(",", var.aws_storage_type_special_kubelet), count.index))}"
     coreos_update_channel = "${var.coreos_update_channel}"
     coreos_reboot_strategy = "${var.coreos_reboot_strategy}"
     short_name = "node-${format("%03d", count.index+1)}"
@@ -431,7 +431,7 @@ resource "aws_instance" "kubernetes_node_special" {
   tags {
     Name = "${var.aws_user_prefix}_${var.aws_cluster_prefix}_node-${format("%03d", count.index+1)}"
     ShortName = "${format("node-%03d", count.index+1)}"
-    StorageType = "${element(split(",", var.aws_storage_type_special), count.index)}"
+    StorageType = "${element(split(",", var.aws_storage_type_special_docker), count.index)}"
   }
 }
 
@@ -460,8 +460,8 @@ resource "template_file" "node_cloudinit" {
     master_private_ip = "${aws_instance.kubernetes_master.private_ip}"
     master_public_ip = "${aws_instance.kubernetes_master.public_ip}"
     cluster_proxy_record = "${var.aws_user_prefix}-proxy.${var.aws_cluster_domain}"
-    format_docker_storage_mnt = "${lookup(var.format_docker_storage_mnt, var.aws_storage_type)}"
-    format_kubelet_storage_mnt = "${lookup(var.format_kubelet_storage_mnt, var.aws_storage_type)}"
+    format_docker_storage_mnt = "${lookup(var.format_docker_storage_mnt, var.aws_storage_type_docker)}"
+    format_kubelet_storage_mnt = "${lookup(var.format_kubelet_storage_mnt, var.aws_storage_type_kubelet)}"
     coreos_update_channel = "${var.coreos_update_channel}"
     coreos_reboot_strategy = "${var.coreos_reboot_strategy}"
     short_name = "autoscaled"
@@ -511,7 +511,7 @@ resource "aws_autoscaling_group" "kubernetes_nodes" {
   health_check_type = "EC2"
   tag {
     key = "StorageType"
-    value = "${var.aws_storage_type}"
+    value = "${var.aws_storage_type_docker}"
     propagate_at_launch = true
   }
   tag {
@@ -570,7 +570,8 @@ resource "template_file" "ansible_inventory" {
     master_public_ip = "${aws_instance.kubernetes_master.public_ip}"
     apiservers_inventory_info = "${join("\n", concat(formatlist("%v ansible_ssh_host=%v", aws_instance.kubernetes_apiserver.*.tags.ShortName, aws_instance.kubernetes_apiserver.*.public_ip)))}"
     cluster_proxy_record = "${var.aws_user_prefix}-proxy.${var.aws_cluster_domain}"
-    format_docker_storage_mnt = "${lookup(var.format_docker_storage_mnt, var.aws_storage_type)}"
+    format_docker_storage_mnt = "${lookup(var.format_docker_storage_mnt, var.aws_storage_type_docker)}"
+    format_kubelet_storage_mnt = "${lookup(var.format_kubelet_storage_mnt, var.aws_storage_type_kubelet)}"
     coreos_update_channel = "${var.coreos_update_channel}"
     coreos_reboot_strategy = "${var.coreos_reboot_strategy}"
     apiserver_nginx_pool = "${join(" ", concat(formatlist("server %v:8080;", aws_instance.kubernetes_apiserver.*.private_ip)))}"

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -245,7 +245,6 @@ resource "aws_instance" "kubernetes_etcd" {
   tags {
     Name = "${var.aws_user_prefix}_${var.aws_cluster_prefix}_etcd"
     ShortName = "etcd"
-    StorageType = "${var.aws_storage_type_etcd}"
   }
 }
 
@@ -301,7 +300,6 @@ resource "aws_instance" "kubernetes_apiserver" {
   tags {
     Name = "${var.aws_user_prefix}_${var.aws_cluster_prefix}_apiserver-${format("%03d", count.index+1)}"
     ShortName = "${format("apiserver-%03d", count.index+1)}"
-    StorageType = "${var.aws_storage_type_apiserver}"
   }
 }
 
@@ -360,7 +358,6 @@ resource "aws_instance" "kubernetes_master" {
   tags {
     Name = "${var.aws_user_prefix}_${var.aws_cluster_prefix}_master"
     ShortName = "master"
-    StorageType = "${var.aws_storage_type_master}"
   }
 }
 
@@ -431,7 +428,6 @@ resource "aws_instance" "kubernetes_node_special" {
   tags {
     Name = "${var.aws_user_prefix}_${var.aws_cluster_prefix}_node-${format("%03d", count.index+1)}"
     ShortName = "${format("node-%03d", count.index+1)}"
-    StorageType = "${element(split(",", var.aws_storage_type_special_docker), count.index)}"
   }
 }
 
@@ -509,11 +505,6 @@ resource "aws_autoscaling_group" "kubernetes_nodes" {
   vpc_zone_identifier = ["${aws_subnet.vpc_subnet.id}"]
   launch_configuration = "${aws_launch_configuration.kubernetes_node.name}"
   health_check_type = "EC2"
-  tag {
-    key = "StorageType"
-    value = "${var.aws_storage_type_node_docker}"
-    propagate_at_launch = true
-  }
   tag {
     key = "Name"
     value = "${var.aws_user_prefix}_${var.aws_cluster_prefix}_node-autoscaled"

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -460,8 +460,8 @@ resource "template_file" "node_cloudinit" {
     master_private_ip = "${aws_instance.kubernetes_master.private_ip}"
     master_public_ip = "${aws_instance.kubernetes_master.public_ip}"
     cluster_proxy_record = "${var.aws_user_prefix}-proxy.${var.aws_cluster_domain}"
-    format_docker_storage_mnt = "${lookup(var.format_docker_storage_mnt, var.aws_storage_type_docker)}"
-    format_kubelet_storage_mnt = "${lookup(var.format_kubelet_storage_mnt, var.aws_storage_type_kubelet)}"
+    format_docker_storage_mnt = "${lookup(var.format_docker_storage_mnt, var.aws_storage_type_node_docker)}"
+    format_kubelet_storage_mnt = "${lookup(var.format_kubelet_storage_mnt, var.aws_storage_type_node_kubelet)}"
     coreos_update_channel = "${var.coreos_update_channel}"
     coreos_reboot_strategy = "${var.coreos_reboot_strategy}"
     short_name = "autoscaled"
@@ -511,7 +511,7 @@ resource "aws_autoscaling_group" "kubernetes_nodes" {
   health_check_type = "EC2"
   tag {
     key = "StorageType"
-    value = "${var.aws_storage_type_docker}"
+    value = "${var.aws_storage_type_node_docker}"
     propagate_at_launch = true
   }
   tag {
@@ -570,8 +570,8 @@ resource "template_file" "ansible_inventory" {
     master_public_ip = "${aws_instance.kubernetes_master.public_ip}"
     apiservers_inventory_info = "${join("\n", concat(formatlist("%v ansible_ssh_host=%v", aws_instance.kubernetes_apiserver.*.tags.ShortName, aws_instance.kubernetes_apiserver.*.public_ip)))}"
     cluster_proxy_record = "${var.aws_user_prefix}-proxy.${var.aws_cluster_domain}"
-    format_docker_storage_mnt = "${lookup(var.format_docker_storage_mnt, var.aws_storage_type_docker)}"
-    format_kubelet_storage_mnt = "${lookup(var.format_kubelet_storage_mnt, var.aws_storage_type_kubelet)}"
+    format_docker_storage_mnt = "${lookup(var.format_docker_storage_mnt, var.aws_storage_type_node_docker)}"
+    format_kubelet_storage_mnt = "${lookup(var.format_kubelet_storage_mnt, var.aws_storage_type_node_kubelet)}"
     coreos_update_channel = "${var.coreos_update_channel}"
     coreos_reboot_strategy = "${var.coreos_reboot_strategy}"
     apiserver_nginx_pool = "${join(" ", concat(formatlist("server %v:8080;", aws_instance.kubernetes_apiserver.*.private_ip)))}"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -86,23 +86,23 @@ variable "aws_storage_type" {
   default = "ebs"
 }
 variable "aws_volume_size_master" {
-  default = "30"
+  default = "10"
   description = "Size of EBS volume attached to master instance in gigabytes."
 }
 variable "aws_volume_size_apiserver" {
-  default = "30"
+  default = "10"
   description = "Size of EBS volume attached to master instance in gigabytes."
 }
 variable "aws_volume_size_etcd" {
-  default = "30"
+  default = "10"
   description = "Size of EBS volume attached to etcd instance in gigabytes."
 }
 variable "aws_volume_size_special" {
-  default = "30"
+  default = "10"
   description = "Sizes of EBS volume attached to special nodes. Comma-sperated list. Count must = special_node_count."
 }
 variable "aws_volume_size" {
-  default = "30"
+  default = "10"
   description = "Size of EBS volume attached to all other nodes in gigabytes."
 }
 variable "aws_volume_type_master" {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -86,7 +86,7 @@ variable "aws_storage_type_special_kubelet" {
   default = "ebs"
 }
 variable "aws_storage_type_special" {
-  description = "[DEPRECATED] Primary volume type for special nodes. Comma-sperated list. Count must = special_node_count"
+  description = "[DEPRECATED] use aws_storage_type_special_docker and aws_storage_type_special_kubelet instead"
   default = "ebs"
 }
 variable "aws_storage_type_node_docker" {
@@ -98,7 +98,7 @@ variable "aws_storage_type_node_kubelet" {
   default = "ebs"
 }
 variable "aws_storage_type" {
-  description = "[DEPRECATED] Primary volume type for all other nodes"
+  description = "[DEPRECATED] use aws_storage_type_node_docker an aws_storage_type_node_kubelet instead"
   default = "ebs"
 }
 variable "aws_volume_size_master" {
@@ -123,7 +123,7 @@ variable "aws_volume_size_special_kubelet" {
 }
 variable "aws_volume_size_special" {
   default = "10"
-  description = "[DEPRECATED] Sizes of EBS volume attached to special nodes. Comma-sperated list. Count must = special_node_count."
+  description = "[DEPRECATED] use aws_volume_size_specal_docker and aws_volume_size_special_kubelet instead"
 }
 variable "aws_volume_size_node_docker" {
   default = "10"
@@ -159,7 +159,7 @@ variable "aws_volume_type_special_kubelet" {
 }
 variable "aws_volume_type_special" {
   default = "gp2"
-  description = "[DEPRECATED] Type of EBS volume attached special nodes. Comma-sperated list. Count must = special_node_count."
+  description = "[DEPRECATED] use aws_volume_type_special_docker and aws_volume_type_special_kubelet instead"
 }
 variable "aws_volume_type_node_docker" {
   default = "gp2"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -77,12 +77,28 @@ variable "aws_storage_type_etcd" {
   description = "Primary volume type for master"
   default = "ebs"
 }
+variable "aws_storage_type_special_docker" {
+  description = "Primary volume type for special nodes for /var/lib/docker. Comma-sperated list. Count must = special_node_count"
+  default = "ebs"
+}
+variable "aws_storage_type_special_kubelet" {
+  description = "Primary volume type for special nodes for /var/lib/kubelet. Comma-sperated list. Count must = special_node_count"
+  default = "ebs"
+}
 variable "aws_storage_type_special" {
-  description = "Primary volume type for sepcial nodes. Comma-sperated list. Count must = special_node_count"
+  description = "[DEPRECATED] Primary volume type for special nodes. Comma-sperated list. Count must = special_node_count"
+  default = "ebs"
+}
+variable "aws_storage_type_node_docker" {
+  description = "Primary volume type for nodes for /var/lib/docker"
+  default = "ebs"
+}
+variable "aws_storage_type_node_kubelet" {
+  description = "Primary volume type for nodes for /var/lib/kubelet"
   default = "ebs"
 }
 variable "aws_storage_type" {
-  description = "Primary volume type for all other nodes"
+  description = "[DEPRECATED] Primary volume type for all other nodes"
   default = "ebs"
 }
 variable "aws_volume_size_master" {
@@ -97,9 +113,25 @@ variable "aws_volume_size_etcd" {
   default = "10"
   description = "Size of EBS volume attached to etcd instance in gigabytes."
 }
+variable "aws_volume_size_special_docker" {
+  default = "10"
+  description = "Sizes of EBS volume attached to special nodes for /var/lib/docker. Comma-sperated list. Count must = special_node_count."
+}
+variable "aws_volume_size_special_kubelet" {
+  default = "10"
+  description = "Sizes of EBS volume attached to special nodes for /var/lib/kubelet. Comma-sperated list. Count must = special_node_count."
+}
 variable "aws_volume_size_special" {
   default = "10"
-  description = "Sizes of EBS volume attached to special nodes. Comma-sperated list. Count must = special_node_count."
+  description = "[DEPRECATED] Sizes of EBS volume attached to special nodes. Comma-sperated list. Count must = special_node_count."
+}
+variable "aws_volume_size_node_docker" {
+  default = "10"
+  description = "Size of EBS volume attached to nodes for /var/lib/docker in gigabytes."
+}
+variable "aws_volume_size_node_kubelet" {
+  default = "10"
+  description = "Size of EBS volume attached to nodes for /var/lib/kubelet in gigabytes"
 }
 variable "aws_volume_size" {
   default = "10"
@@ -117,13 +149,29 @@ variable "aws_volume_type_etcd" {
   default = "gp2"
   description = "Type of EBS volume attached to etcd AWS instance. "
 }
+variable "aws_volume_type_special_docker" {
+  default = "gp2"
+  description = "Type of EBS volume attached special nodes for /var/lib/docker. Comma-sperated list. Count must = special_node_count."
+}
+variable "aws_volume_type_special_kubelet" {
+  default = "gp2"
+  description = "Type of EBS volume attached special nodes for /var/lib/kubelet. Comma-sperated list. Count must = special_node_count."
+}
 variable "aws_volume_type_special" {
   default = "gp2"
-  description = "Type of EBS volume attached special nodes. Comma-sperated list. Count must = special_node_count."
+  description = "[DEPRECATED] Type of EBS volume attached special nodes. Comma-sperated list. Count must = special_node_count."
+}
+variable "aws_volume_type_node_docker" {
+  default = "gp2"
+  description = "Type of EBS volume attached to node for /var/lib/docker"
+}
+variable "aws_volume_type_node_kubelet" {
+  default = "gp2"
+  description = "Type of EBS volume attached to nodes for /var/lib/kubelet"
 }
 variable "aws_volume_type" {
   default = "gp2"
-  description = "Type of EBS volume attached to all other nodes."
+  description = "[DEPRECATED] Type of EBS volume attached to all other nodes."
 }
 variable "aws_storage_path" {
   default =  {


### PR DESCRIPTION
I'd like to outright remove the variables I've marked as deprecated, but would like some feedback to see if this is the right path.