### PR TITLE
KRAK-185 correct the arg

### DIFF
--- a/ansible/roles/kubernetes/templates/generate-kube-cert.sh.ansible
+++ b/ansible/roles/kubernetes/templates/generate-kube-cert.sh.ansible
@@ -14,7 +14,7 @@ if [ ${check} == 200 ]
 		echo "ERROR: Kubernetes certs and tokens already exists"; 	exit 0
 	else
 		# Generate the certs and tokens and stuff them into etcd
-		${kraken_loc}/generate-cert/make-cert-tokens.sh {{master_private_ip}} {{master_private_ip}} /srv/kubernetes
+		${kraken_loc}/generate-cert/make-cert-tokens.sh {{master_private_ip}} {{dns_ip}} /srv/kubernetes
 		/usr/bin/tar -zcvf /tmp/kube-cert.tgz /srv/kubernetes
 		/usr/bin/cat /tmp/kube-cert.tgz | base64 > /tmp/kube-cert.base64
 		/usr/bin/etcdctl set ${key} < /tmp/kube-cert.base64


### PR DESCRIPTION
Fixes many of the failing conformance tests.
Most tests do a direct https queris of the kubernetes service endpoint.  This requires that the created ca.crt that is mounted in each Pod has that IP listed in its authorized IP list.  
