### PR TITLE
Bypass journald for kubernetes components

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yaml
+++ b/ansible/roles/kubernetes/defaults/main.yaml
@@ -10,11 +10,13 @@ kraken_services_repo: git://github.com/samsung-ag/kraken-services
 kraken_services_dirs: "heapster kube-ui prometheus"
 kubernetes_api_version: v1
 kubernetes_binaries_uri: https://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/linux/amd64
+kubernetes_log_dir: /var/log/k8s
 kubernetes_systemd_stderr: "journal"
 kubernetes_systemd_stdout: "journal"
 kube_apiserver:
   # https://github.com/kubernetes/kubernetes/blob/release-1.1/docs/admin/admission-controllers.md#is-there-a-recommended-set-of-plug-ins-to-use
   admission-control: NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+  alsologtostderr: false
   bind-address: 0.0.0.0
   client-ca-file: /srv/kubernetes/ca.crt
   cors-allowed-origins: .*
@@ -25,7 +27,8 @@ kube_apiserver:
   insecure-bind-address: 0.0.0.0
   insecure-port: 8080
   kubelet-timeout: 5s
-  logtostderr: true
+  log_dir: "{{ kubernetes_log_dir }}/apiserver"
+  logtostderr: false
   max-requests-inflight: 400
   profiling: true
   runtime_config: "api/{{kubernetes_api_version}}"
@@ -38,10 +41,12 @@ kube_apiserver:
   v: 1
 kube_controller_manager:
   address: "{{ master_private_ip }}"
+  alsologtostderr: false
   concurrent-endpoint-syncs: 5
   concurrent-rc-syncs: 5
   deleting-pods-burst: 10
-  logtostderr: true
+  log_dir: "{{ kubernetes_log_dir }}/controller-manager"
+  logtostderr: false
   master: "{{ master_private_ip }}:8080"
   namespace-sync-period: 5m0s
   node-monitor-grace-period: 40s
@@ -59,13 +64,17 @@ kube_controller_manager:
   service-sync-period: 5m0s
   v: 1
 kube_proxy:
+  alsologtostderr: false
   kubeconfig: /srv/kubernetes/kube-proxy/kubeconfig
-  logtostderr: true
+  log_dir: "{{ kubernetes_log_dir }}/proxy"
+  logtostderr: false
   master: "{{ master_private_ip }}:8080"
   v: 1
 kube_scheduler:
   address: "{{ master_private_ip }}"
-  logtostderr: true
+  alsologtostderr: false
+  log_dir: "{{ kubernetes_log_dir }}/scheduler"
+  logtostderr: false
   master: "{{ master_private_ip }}:8080"
   port: 10251
   profiling: true
@@ -73,6 +82,7 @@ kube_scheduler:
 kubelet:
   address: 0.0.0.0
   api-servers: "http://{{ master_private_ip }}:8080"
+  alsologtostderr: false
   cadvisor-port: 4194
   cluster-dns: "{{ dns_ip }}"
   cluster-domain: "{{ dns_domain }}"
@@ -84,7 +94,8 @@ kubelet:
   # TODO: do we have access to ansible_local here?
   # hostname_override: "{{ ansible_local.kubernetes_node_ip_fact.node_ip_address }}"
   kubeconfig: /srv/kubernetes/kubelet/kubeconfig
-  logtostderr: true
+  log_dir: "{{ kubernetes_log_dir }}/kubelet"
+  logtostderr: false
   # max-pods: 40
   max-pods: 200
   node-status-update-frequency: 10s

--- a/ansible/roles/kubernetes/templates/hyperkube-binary-apiserver.service.ansible
+++ b/ansible/roles/kubernetes/templates/hyperkube-binary-apiserver.service.ansible
@@ -9,6 +9,7 @@ StandardError={{ kubernetes_systemd_stderr }}
 Restart=always
 RestartSec=5
 LimitNOFILE=infinity
+ExecStartPre=-/usr/bin/mkdir -p {{kube_apiserver.log_dir}}
 ExecStartPre=-/usr/bin/mv -v /opt/bin/hyperkube.pending /opt/bin/hyperkube
 ExecStart=/opt/bin/hyperkube apiserver \
   {% for k,v in kube_apiserver.iteritems() %}

--- a/ansible/roles/kubernetes/templates/hyperkube-binary-controller-manager.service.ansible
+++ b/ansible/roles/kubernetes/templates/hyperkube-binary-controller-manager.service.ansible
@@ -9,6 +9,7 @@ StandardError={{ kubernetes_systemd_stderr }}
 Restart=always
 RestartSec=5
 LimitNOFILE=infinity
+ExecStartPre=-/usr/bin/mkdir -p {{kube_controller_manager.log_dir}}
 ExecStartPre=-/usr/bin/mv -v /opt/bin/hyperkube.pending /opt/bin/hyperkube
 ExecStart=/opt/bin/hyperkube controller-manager \
   {% for k,v in kube_controller_manager.iteritems() %}

--- a/ansible/roles/kubernetes/templates/hyperkube-binary-kubelet.service.ansible
+++ b/ansible/roles/kubernetes/templates/hyperkube-binary-kubelet.service.ansible
@@ -10,6 +10,7 @@ StandardError={{ kubernetes_systemd_stderr }}
 Restart=always
 RestartSec=5
 EnvironmentFile=/etc/network-environment
+ExecStartPre=-/usr/bin/mkdir -p {{kubelet.log_dir}}
 ExecStartPre=-/usr/bin/mv -v /opt/bin/hyperkube.pending /opt/bin/hyperkube
 ExecStart=/opt/bin/hyperkube kubelet \
   {% for k,v in kubelet.iteritems() %}

--- a/ansible/roles/kubernetes/templates/hyperkube-binary-proxy.service.ansible
+++ b/ansible/roles/kubernetes/templates/hyperkube-binary-proxy.service.ansible
@@ -10,6 +10,7 @@ StandardError={{ kubernetes_systemd_stderr }}
 Restart=always
 RestartSec=5
 LimitNOFILE=infinity
+ExecStartPre=-/usr/bin/mkdir -p {{kube_proxy.log_dir}}
 ExecStartPre=-/usr/bin/mv -v /opt/bin/hyperkube.pending /opt/bin/hyperkube
 ExecStart=/opt/bin/hyperkube proxy \
   {% for k,v in kube_proxy.iteritems() %}

--- a/ansible/roles/kubernetes/templates/hyperkube-binary-scheduler.service.ansible
+++ b/ansible/roles/kubernetes/templates/hyperkube-binary-scheduler.service.ansible
@@ -9,6 +9,7 @@ StandardError={{ kubernetes_systemd_stderr }}
 Restart=always
 RestartSec=5
 LimitNOFILE=infinity
+ExecStartPre=-/usr/bin/mkdir -p {{kube_scheduler.log_dir}}
 ExecStartPre=-/usr/bin/mv -v /opt/bin/hyperkube.pending /opt/bin/hyperkube
 ExecStart=/opt/bin/hyperkube scheduler \
   {% for k,v in kube_scheduler.iteritems() %}

--- a/ansible/roles/kubernetes/templates/hyperkube-docker-apiserver.service.ansible
+++ b/ansible/roles/kubernetes/templates/hyperkube-docker-apiserver.service.ansible
@@ -10,6 +10,7 @@ StandardError={{ kubernetes_systemd_stderr }}
 Restart=always
 RestartSec=5
 LimitNOFILE=infinity
+ExecStartPre=-/usr/bin/mkdir -p {{kube_apiserver.log_dir}}
 ExecStartPre=-/usr/bin/docker kill kube-apiserver
 ExecStartPre=-/usr/bin/docker rm kube-apiserver
 ExecStartPre=-/usr/bin/docker kill $(docker ps -a -q --filter="name=k8s-apiserver")
@@ -21,6 +22,7 @@ ExecStart=/usr/bin/docker run \
   -v /opt/bin/manifests:/etc/kubernetes/manifests-override \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /srv/kubernetes:/srv/kubernetes \
+  -v {{kube_apiserver.log_dir}}:{{kube_apiserver.log_dir}}
   {{hyperkube_image}} \
     /hyperkube \
     kubelet \

--- a/ansible/roles/kubernetes/templates/hyperkube-docker-master.service.ansible
+++ b/ansible/roles/kubernetes/templates/hyperkube-docker-master.service.ansible
@@ -10,6 +10,8 @@ StandardError={{ kubernetes_systemd_stderr }}
 Restart=always
 RestartSec=5
 LimitNOFILE=infinity
+ExecStartPre=-/usr/bin/mkdir -p {{kube_controller_manager.log_dir}}
+ExecStartPre=-/usr/bin/mkdir -p {{kube_scheduler.log_dir}}
 ExecStartPre=-/usr/bin/docker kill kube-master
 ExecStartPre=-/usr/bin/docker rm kube-master
 ExecStartPre=-/usr/bin/docker kill $(docker ps -a -q --filter="name=k8s-master")
@@ -21,6 +23,8 @@ ExecStart=/usr/bin/docker run \
   -v /opt/bin/manifests:/etc/kubernetes/manifests-override \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /srv/kubernetes:/srv/kubernetes \
+  -v {{kube_scheduler.log_dir}}:{{kube_scheduler.log_dir}} \ 
+  -v {{kube_controller_manager.log_dir}}:{{kube_controller_manager.log_dir}} \
   {{hyperkube_image}} \
     /hyperkube \
     kubelet \

--- a/ansible/roles/kubernetes/templates/hyperkube-docker-node.service.ansible
+++ b/ansible/roles/kubernetes/templates/hyperkube-docker-node.service.ansible
@@ -11,6 +11,7 @@ StandardOuptut={{ kubernetes_systemd_stdout }}
 StandardError={{ kubernetes_systemd_stderr }}
 Restart=always
 RestartSec=5
+ExecStartPre=-/usr/bin/mkdir -p {{kubelet.log_dir}}
 ExecStartPre=-/usr/bin/docker kill kube-node
 ExecStartPre=-/usr/bin/docker rm kube-node
 ExecStart=/usr/bin/docker run \
@@ -19,6 +20,7 @@ ExecStart=/usr/bin/docker run \
   --privileged \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /srv/kubernetes:/srv/kubernetes \
+  -v {{kubelet.log_dir}}:{{kubelet.log_dir}}
   {{hyperkube_image}} \
     /hyperkube kubelet \
     {% for k,v in kubelet.iteritems() %}

--- a/ansible/roles/kubernetes/templates/hyperkube-docker-proxy-node.service.ansible
+++ b/ansible/roles/kubernetes/templates/hyperkube-docker-proxy-node.service.ansible
@@ -9,6 +9,7 @@ StandardOuptut={{ kubernetes_systemd_stdout }}
 StandardError={{ kubernetes_systemd_stderr }}
 Restart=always
 RestartSec=5
+ExecStartPre=-/usr/bin/mkdir -p {{kube_proxy.log_dir}}
 ExecStartPre=-/usr/bin/docker kill kube-proxy
 ExecStartPre=-/usr/bin/docker rm kube-proxy
 ExecStart=/usr/bin/docker run \
@@ -16,6 +17,7 @@ ExecStart=/usr/bin/docker run \
   --net=host \
   --privileged \
   -v /srv/kubernetes:/srv/kubernetes \
+  -v {{kube_proxy.log_dir}}:{{kube_proxy.log_dir}} \
   {{hyperkube_image}} \
     /hyperkube proxy \
     {% for k,v in kube_proxy.iteritems() %}

--- a/ansible/roles/kubernetes/templates/hyperkube-docker-proxy.service.ansible
+++ b/ansible/roles/kubernetes/templates/hyperkube-docker-proxy.service.ansible
@@ -9,6 +9,7 @@ StandardOuptut={{ kubernetes_systemd_stdout }}
 StandardError={{ kubernetes_systemd_stderr }}
 Restart=always
 RestartSec=5
+ExecStartPre=-/usr/bin/mkdir -p {{kube_proxy.log_dir}}
 ExecStartPre=-/usr/bin/docker kill kube-proxy
 ExecStartPre=-/usr/bin/docker rm kube-proxy
 ExecStart=/usr/bin/docker run \
@@ -16,6 +17,7 @@ ExecStart=/usr/bin/docker run \
   --net=host \
   --privileged \
   -v /srv/kubernetes:/srv/kubernetes \
+  -v {{kube_proxy.log_dir}}:{{kube_proxy.log_dir}} \
   {{hyperkube_image}} \
     /hyperkube proxy \
     {% for k,v in kube_proxy.iteritems() %}


### PR DESCRIPTION
Workaround for coreos/bugs#990

Logging to stderr is unbuffered, so whatever is causing systemd-journald
to block / not process messages fast enough eventually causes the kube
components logging to stderr to block

Use a log_dir parameter to have the kubernetes components log directly
to files.  Seemed more flexible than writing a wrapper shell script to
`>> /var/log/k8s/foo 2>&1` although not sure I'm a fan of the way files
are broken out per-level

For now /var/log/k8s is still on the root volume. If we find we're
getting i/o limited there, we should follow up with something that puts
that on a more performant volume.