### PR TITLE
Remove docker-tcp.socket

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yaml
+++ b/ansible/roles/kubernetes/defaults/main.yaml
@@ -32,7 +32,6 @@ kube_apiserver:
   max-requests-inflight: 400
   profiling: true
   runtime_config: "api/{{kubernetes_api_version}}"
-  secure-port: 0
   secure_port: 443
   service-cluster-ip-range: 10.100.0.0/16
   tls-cert-file: /srv/kubernetes/server.cert

--- a/terraform/aws/templates/apiserver.yaml.tpl
+++ b/terraform/aws/templates/apiserver.yaml.tpl
@@ -70,20 +70,6 @@ coreos:
         What=${format_docker_storage_mnt}
         Where=/var/lib/docker
         Type=ext4
-    - name: docker-tcp.socket
-      command: start
-      enable: true
-      content: |
-        [Unit]
-        Description=Docker TCP Socket for the API
-
-        [Socket]
-        ListenStream=0.0.0.0:4243
-        BindIPv6Only=both
-        Service=docker.service
-
-        [Install]
-        WantedBy=sockets.target
     - name: etcd2.service
       command: start
     - name: setup-network-environment.service

--- a/terraform/aws/templates/master.yaml.tpl
+++ b/terraform/aws/templates/master.yaml.tpl
@@ -75,20 +75,6 @@ coreos:
         What=${format_docker_storage_mnt}
         Where=/var/lib/docker
         Type=ext4
-    - name: docker-tcp.socket
-      command: start
-      enable: true
-      content: |
-        [Unit]
-        Description=Docker TCP Socket for the API
-
-        [Socket]
-        ListenStream=0.0.0.0:4243
-        BindIPv6Only=both
-        Service=docker.service
-
-        [Install]
-        WantedBy=sockets.target
     - name: etcd2.service
       command: start
     - name: setup-network-environment.service

--- a/terraform/aws/templates/node.yaml.tpl
+++ b/terraform/aws/templates/node.yaml.tpl
@@ -88,20 +88,6 @@ coreos:
         What=${format_kubelet_storage_mnt}
         Where=/var/lib/kubelet
         Type=ext4
-    - name: docker-tcp.socket
-      command: start
-      enable: true
-      content: |
-        [Unit]
-        Description=Docker Socket for the API
-
-        [Socket]
-        ListenStream=0.0.0.0:4243
-        BindIPv6Only=both
-        Service=docker.service
-
-        [Install]
-        WantedBy=sockets.target
     - name: setup-network-environment.service
       command: start
       content: |

--- a/terraform/local/templates/apiserver.yaml.tpl
+++ b/terraform/local/templates/apiserver.yaml.tpl
@@ -46,20 +46,6 @@ coreos:
           content: |
             [Service]
             Environment="DOCKER_OPTS=--log-level=warn"
-    - name: docker-tcp.socket
-      command: start
-      enable: true
-      content: |
-        [Unit]
-        Description=Docker TCP Socket for the API
-
-        [Socket]
-        ListenStream=0.0.0.0:4243
-        BindIPv6Only=both
-        Service=docker.service
-
-        [Install]
-        WantedBy=sockets.target
     - name: etcd2.service
       command: start
     - name: setup-network-environment.service

--- a/terraform/local/templates/master.yaml.tpl
+++ b/terraform/local/templates/master.yaml.tpl
@@ -50,20 +50,6 @@ coreos:
           content: |
             [Service]
             Environment="DOCKER_OPTS=--log-level=warn"
-    - name: docker-tcp.socket
-      command: start
-      enable: true
-      content: |
-        [Unit]
-        Description=Docker TCP Socket for the API
-
-        [Socket]
-        ListenStream=0.0.0.0:4243
-        BindIPv6Only=both
-        Service=docker.service
-
-        [Install]
-        WantedBy=sockets.target
     - name: etcd2.service
       command: start
     - name: setup-network-environment.service

--- a/terraform/local/templates/node.yaml.tpl
+++ b/terraform/local/templates/node.yaml.tpl
@@ -44,20 +44,6 @@ coreos:
           content: |
             [Service]
             Environment="DOCKER_OPTS=--log-level=warn"
-    - name: docker-tcp.socket
-      command: start
-      enable: true
-      content: |
-        [Unit]
-        Description=Docker Socket for the API
-
-        [Socket]
-        ListenStream=0.0.0.0:4243
-        BindIPv6Only=both
-        Service=docker.service
-
-        [Install]
-        WantedBy=sockets.target
     - name: setup-network-environment.service
       command: start
       content: |


### PR DESCRIPTION
The kubernetes components talk to it via a file descriptor, no point in
exposing docker via TCP let alone on 0.0.0.0 if we don't need it.