### PR TITLE
Increase node registration reliability

### DIFF
--- a/ansible/roles/kubernetes/tasks/apiserver-binary.yaml
+++ b/ansible/roles/kubernetes/tasks/apiserver-binary.yaml
@@ -9,6 +9,10 @@
     #      parameterize a list of handlers for the install-hyperkube handler to notify
     - restart hyperkube-binary-apiserver
 
+- name: Ensure install-hyperkube.service started
+  service: name=install-hyperkube state=started enabled=yes args=--no-block
+  sudo: yes
+
 - name: Create hyperkube-binary-apiserver
   template: src=hyperkube-binary-apiserver.service.ansible
             dest=/etc/systemd/system/hyperkube-binary-apiserver.service
@@ -16,3 +20,7 @@
   notify:
     - reload systemd
     - restart hyperkube-binary-apiserver
+
+- name: Ensure hyperkube-binary-apiserver.service started
+  service: name=hyperkube-binary-apiserver state=started enabled=yes args=--no-block
+  sudo: yes

--- a/ansible/roles/kubernetes/tasks/apiserver-docker.yaml
+++ b/ansible/roles/kubernetes/tasks/apiserver-docker.yaml
@@ -18,4 +18,9 @@
   sudo: yes
   notify:
     - reload systemd
-    - restart hyperkube-docker-master
+    - restart hyperkube-docker-apiserver
+
+- name: Ensure hyperkube-docker-apiserver.service started
+  service: name=hyperkube-docker-apiserver state=started enabled=yes args=--no-block
+  sudo: yes
+

--- a/ansible/roles/kubernetes/tasks/cadvisor.yaml
+++ b/ansible/roles/kubernetes/tasks/cadvisor.yaml
@@ -6,3 +6,8 @@
   notify:
     - reload systemd
     - restart cadvisor
+
+- name: Ensure cadvisor.service started
+  service: name=cadvisor state=started enabled=yes args=--no-block
+  sudo: yes
+

--- a/ansible/roles/kubernetes/tasks/generate-kube-cert.yaml
+++ b/ansible/roles/kubernetes/tasks/generate-kube-cert.yaml
@@ -20,3 +20,8 @@
   notify:
     - reload systemd
     - restart generate-kube-cert
+
+- name: Ensure generate-kube-cert.service started
+  service: name=generate-kube-cert state=started enabled=yes args=--no-block
+  sudo: yes
+      

--- a/ansible/roles/kubernetes/tasks/kraken-services.yaml
+++ b/ansible/roles/kubernetes/tasks/kraken-services.yaml
@@ -48,6 +48,10 @@
     - reload systemd
     - restart kraken-render
 
+- name: Ensure kraken-render.service started
+  service: name=kraken-render state=started enabled=yes args=--no-block
+  sudo: yes
+
 - name: Create kraken-create-services
   template: src=kraken-create-services.service.ansible
             dest=/etc/systemd/system/kraken-create-services.service
@@ -55,3 +59,8 @@
   notify:
     - reload systemd
     - restart kraken-create-services
+
+- name: Ensure kraken-create-services.service started
+  service: name=kraken-create-services state=started enabled=yes args=--no-block
+  sudo: yes
+

--- a/ansible/roles/kubernetes/tasks/kubectl.yaml
+++ b/ansible/roles/kubernetes/tasks/kubectl.yaml
@@ -5,3 +5,8 @@
   notify:
     - reload systemd
     - restart install-kubectl
+
+- name: Ensure install-kubectl.service started
+  service: name=install-kubectl state=started enabled=yes args=--no-block
+  sudo: yes
+

--- a/ansible/roles/kubernetes/tasks/load-kube-cert.yaml
+++ b/ansible/roles/kubernetes/tasks/load-kube-cert.yaml
@@ -19,3 +19,8 @@
   notify:
     - reload systemd
     - restart load-kube-cert
+
+- name: Ensure load-kube-cert.service started
+  service: name=load-kube-cert state=started enabled=yes args=--no-block
+  sudo: yes
+

--- a/ansible/roles/kubernetes/tasks/master-binary.yaml
+++ b/ansible/roles/kubernetes/tasks/master-binary.yaml
@@ -11,6 +11,10 @@
     - restart hyperkube-binary-controller-manager
     - restart hyperkube-binary-scheduler
 
+- name: Ensure install-hyperkube.service started
+  service: name=install-hyperkube state=started enabled=yes args=--no-block
+  sudo: yes
+
 - name: Create hyperkube-binary-controller-manager
   template: src=hyperkube-binary-controller-manager.service.ansible
             dest=/etc/systemd/system/hyperkube-binary-controller-manager.service
@@ -19,6 +23,10 @@
     - reload systemd
     - restart hyperkube-binary-controller-manager
 
+- name: Ensure hyperkube-binary-controller-manager.service started
+  service: name=hyperkube-binary-controller-manager state=started enabled=yes args=--no-block
+  sudo: yes
+
 - name: Create hyperkube-binary-scheduler
   template: src=hyperkube-binary-scheduler.service.ansible
             dest=/etc/systemd/system/hyperkube-binary-scheduler.service
@@ -26,3 +34,7 @@
   notify:
     - reload systemd
     - restart hyperkube-binary-scheduler
+
+- name: Ensure hyperkube-binary-scheduler.service started
+  service: name=hyperkube-binary-scheduler state=started enabled=yes args=--no-block
+  sudo: yes

--- a/ansible/roles/kubernetes/tasks/master-docker.yaml
+++ b/ansible/roles/kubernetes/tasks/master-docker.yaml
@@ -23,6 +23,10 @@
     - reload systemd
     - restart hyperkube-docker-master
 
+- name: Ensure hyperkube-docker-master.service started
+  service: name=hyperkube-docker-master state=started enabled=yes args=--no-block
+  sudo: yes
+
 - name: Create hyperkube-docker-proxy
   template: src=hyperkube-docker-proxy.service.ansible
             dest=/etc/systemd/system/hyperkube-docker-proxy.service
@@ -30,3 +34,8 @@
   notify:
     - reload systemd
     - restart hyperkube-docker-proxy
+
+- name: Ensure hyperkube-docker-proxy.service started
+  service: name=hyperkube-docker-proxy state=started enabled=yes args=--no-block
+  sudo: yes
+

--- a/ansible/roles/kubernetes/tasks/nginx-proxy.yaml
+++ b/ansible/roles/kubernetes/tasks/nginx-proxy.yaml
@@ -31,3 +31,8 @@
   notify:
     - reload systemd
     - restart nginx-docker
+
+- name: Ensure nginx-docker.service started
+  service: name=nginx-docker state=started enabled=yes args=--no-block
+  sudo: yes
+

--- a/ansible/roles/kubernetes/tasks/node-binary.yaml
+++ b/ansible/roles/kubernetes/tasks/node-binary.yaml
@@ -9,6 +9,10 @@
     - restart hyperkube-binary-kubelet
     - restart hyperkube-binary-proxy
 
+- name: Ensure install-hyperkube.service started
+  service: name=install-hyperkube state=started enabled=yes args=--no-block
+  sudo: yes
+
 - name: Create hyperkube-binary-kubelet
   template: src=hyperkube-binary-kubelet.service.ansible
             dest=/etc/systemd/system/hyperkube-binary-kubelet.service
@@ -17,6 +21,10 @@
     - reload systemd
     - restart hyperkube-binary-kubelet
 
+- name: Ensure hyperkube-binary-kubelet.service started
+  service: name=hyperkube-binary-kubelet state=started enabled=yes args=--no-block
+  sudo: yes
+
 - name: Create hyperkube-binary-proxy
   template: src=hyperkube-binary-proxy.service.ansible
             dest=/etc/systemd/system/hyperkube-binary-proxy.service
@@ -24,3 +32,7 @@
   notify:
     - reload systemd
     - restart hyperkube-binary-proxy
+
+- name: Ensure hyperkube-binary-proxy.service started
+  service: name=hyperkube-binary-proxy state=started enabled=yes args=--no-block
+  sudo: yes

--- a/ansible/roles/kubernetes/tasks/node-docker.yaml
+++ b/ansible/roles/kubernetes/tasks/node-docker.yaml
@@ -8,6 +8,10 @@
     - reload systemd
     - restart hyperkube-docker-node
 
+- name: Ensure hyperkube-docker-node.service started
+  service: name=hyperkube-docker-node state=started enabled=yes args=--no-block
+  sudo: yes
+
 - name: Create hyperkube-docker-node-proxy
   template: src=hyperkube-docker-proxy-node.service.ansible
             dest=/etc/systemd/system/hyperkube-docker-proxy-node.service
@@ -15,3 +19,7 @@
   notify:
     - reload systemd
     - restart hyperkube-docker-proxy-node
+
+- name: Ensure hyperkube-docker-proxy-node.service started
+  service: name=hyperkube-docker-proxy-node state=started enabled=yes args=--no-block
+  sudo: yes

--- a/ansible/roles/kubernetes/tasks/node-post.yaml
+++ b/ansible/roles/kubernetes/tasks/node-post.yaml
@@ -15,3 +15,8 @@
   notify:
     - reload systemd
     - restart kubernetes-label
+
+- name: Ensure kubernetes-label.service started
+  service: name=kubernetes-label state=started enabled=yes args=--no-block
+  sudo: yes
+

--- a/bin/kraken-up.sh
+++ b/bin/kraken-up.sh
@@ -83,13 +83,17 @@ docker build -t samsung_ag/kraken -f "${KRAKEN_ROOT}/terraform/${KRAKEN_CLUSTER_
 # run cluster up
 inf "Building kraken cluster:\n  'docker run -d --volumes-from kraken_data samsung_ag/kraken terraform apply \
   -input=false -state=/kraken_data/${KRAKEN_CLUSTER_NAME}/terraform.tfstate -var-file=/opt/kraken/terraform/${KRAKEN_CLUSTER_TYPE}/terraform.tfvars /opt/kraken/terraform/${KRAKEN_CLUSTER_TYPE}'"
-docker run -d --name kraken_cluster --volumes-from kraken_data samsung_ag/kraken bash -c "mkdir -p /kraken_data/${KRAKEN_CLUSTER_NAME} && \
-    terraform apply -input=false -state=/kraken_data/${KRAKEN_CLUSTER_NAME}/terraform.tfstate \
+docker run -d --name kraken_cluster --volumes-from kraken_data samsung_ag/kraken bash -c "\
+  mkdir -p /kraken_data/${KRAKEN_CLUSTER_NAME} && \
+  terraform apply \
+    -input=false \
+    -state=/kraken_data/${KRAKEN_CLUSTER_NAME}/terraform.tfstate \
     -var-file=/opt/kraken/terraform/${KRAKEN_CLUSTER_TYPE}/terraform.tfvars \
-    -var 'cluster_name=${KRAKEN_CLUSTER_NAME}' /opt/kraken/terraform/${KRAKEN_CLUSTER_TYPE} && \
-    cp /opt/kraken/terraform/${KRAKEN_CLUSTER_TYPE}/rendered/ansible.inventory  /kraken_data/${KRAKEN_CLUSTER_NAME}/ansible.inventory && \
-    cp /root/.ssh/config_${KRAKEN_CLUSTER_NAME} /kraken_data/${KRAKEN_CLUSTER_NAME}/ssh_config && \
-    cp /root/.kube/config /kraken_data/kube_config"
+    -var 'cluster_name=${KRAKEN_CLUSTER_NAME}' \
+    /opt/kraken/terraform/${KRAKEN_CLUSTER_TYPE} && \
+  cp /opt/kraken/terraform/${KRAKEN_CLUSTER_TYPE}/rendered/ansible.inventory /kraken_data/${KRAKEN_CLUSTER_NAME}/ansible.inventory && \
+  cp /root/.ssh/config_${KRAKEN_CLUSTER_NAME} /kraken_data/${KRAKEN_CLUSTER_NAME}/ssh_config && \
+  cp /root/.kube/config /kraken_data/kube_config"
 
 inf "Following docker logs now. Ctrl-C to cancel."
 docker logs --follow kraken_cluster


### PR DESCRIPTION
~10-20% of nodes were having issues with `ansible-in-docker` dying on its first run, in a way that would prevent necessary services from being loaded/started on subsequent runs

The band-aid here is to explicitly declare services with `state=started` in addition to having handlers to handle `state=restarted` (eg: modifying a services' unit file in-place merits a restart)

The problem is this still keeps running into the need to run `systemctl daemon-reload` before new services are loaded in.  The net result is ansible is failing a lot more frequently now, but it will eventually make it all the way through.

~1% of nodes fail to register now