### PR TITLE
Bind kube master components to 0.0.0.0

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yaml
+++ b/ansible/roles/kubernetes/defaults/main.yaml
@@ -44,7 +44,7 @@ kube_apiserver:
 master_port: "{{master_port}}"
 master_scheme: "{{master_scheme}}"
 kube_controller_manager:
-  address: "{{ master_private_ip }}"
+  address: 0.0.0.0
   alsologtostderr: false
   kubeconfig: "{{ kubernetes_cert_dir }}/system:controller_manager/kubeconfig"
   concurrent-endpoint-syncs: 5
@@ -76,7 +76,7 @@ kube_proxy:
   master: "{{master_scheme}}://{{ master_private_ip }}:{{master_port}}"
   v: 1
 kube_scheduler:
-  address: "{{ master_private_ip }}"
+  address: 0.0.0.0
   alsologtostderr: false
   kubeconfig: "{{ kubernetes_cert_dir }}/system:scheduler/kubeconfig"
   log_dir: "{{ kubernetes_log_dir }}/scheduler"

--- a/ansible/roles/kubernetes/defaults/main.yaml
+++ b/ansible/roles/kubernetes/defaults/main.yaml
@@ -5,27 +5,28 @@ etcd_private_ip: 127.0.0.1
 hyperkube_deployment_mode: binary
 hyperkube_image: gcr.io/google_containers/hyperkube:v1.1.1
 kraken_services_branch: master
-kraken_services_repo: git://github.com/samsung-ag/kraken-services
 # TODO: can we avoid the skydns hardcode and just specify it here?
 kraken_services_dirs: "heapster kube-ui prometheus"
+kraken_services_repo: git://github.com/samsung-ag/kraken-services
 kubernetes_api_version: v1
 kubernetes_binaries_uri: https://storage.googleapis.com/kubernetes-release/release/v1.1.1/bin/linux/amd64
 kubernetes_log_dir: /var/log/k8s
+# kubernetes_service_ip must be within kube_apiserver.service-cluster-ip-range CIDR
+kubernetes_service_ip: 10.100.0.1
 kubernetes_systemd_stderr: "journal"
 kubernetes_systemd_stdout: "journal"
-# this needs to be kept in sync with kube_apiserver.service-cluster-ip-range CIDR
-kubernetes_service_ip: 10.100.0.1
 kube_apiserver:
   # https://github.com/kubernetes/kubernetes/blob/release-1.1/docs/admin/admission-controllers.md#is-there-a-recommended-set-of-plug-ins-to-use
   admission-control: NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
   alsologtostderr: false
+  basic-auth-file: "{{ kubernetes_cert_dir }}/basic_auth.csv"
   bind-address: 0.0.0.0
   client-ca-file: "{{ kubernetes_cert_dir }}/kube-ca.pem"
   cors-allowed-origins: .*
-  event-ttl: 1h0m0s
   etcd-servers: "http://{{etcd_private_ip}}:4001"
   # TODO: enable this once we've got a separate etcd instance
   # etcd-servers-overrides: "/events#http://{{etcd_private_ip}}:4001"
+  event-ttl: 1h0m0s
   insecure-bind-address: 0.0.0.0
   insecure-port: 8080
   kubelet-timeout: 5s
@@ -39,17 +40,14 @@ kube_apiserver:
   tls-cert-file: "{{ kubernetes_cert_dir }}/kube-ca.pem"
   tls-private-key-file: "{{ kubernetes_cert_dir }}/kube-ca-key.pem"
   token-auth-file: "{{ kubernetes_cert_dir }}/known_tokens.csv"
-  basic-auth-file: "{{ kubernetes_cert_dir }}/basic_auth.csv"
   v: 1
-master_port: "{{master_port}}"
-master_scheme: "{{master_scheme}}"
 kube_controller_manager:
   address: 0.0.0.0
   alsologtostderr: false
-  kubeconfig: "{{ kubernetes_cert_dir }}/system:controller_manager/kubeconfig"
   concurrent-endpoint-syncs: 5
   concurrent-rc-syncs: 5
   deleting-pods-burst: 10
+  kubeconfig: "{{ kubernetes_cert_dir }}/system:controller_manager/kubeconfig"
   log_dir: "{{ kubernetes_log_dir }}/controller-manager"
   logtostderr: false
   master: "{{master_scheme}}://{{ master_private_ip }}:{{master_port}}"
@@ -87,13 +85,12 @@ kube_scheduler:
   v: 1
 kubelet:
   address: 0.0.0.0
-  api-servers: "{{master_scheme}}://{{ master_private_ip }}:{{master_port}}"
   alsologtostderr: false
+  api-servers: "{{master_scheme}}://{{ master_private_ip }}:{{master_port}}"
   cadvisor-port: 4194
   cluster-dns: "{{ dns_ip }}"
   cluster-domain: "{{ dns_domain }}"
   enable-debugging-handlers: true
-  # enable-server: false
   enable-server: true
   healthz-bind-address: 0.0.0.0
   healthz-port: 10254
@@ -102,7 +99,6 @@ kubelet:
   kubeconfig: "{{ kubernetes_cert_dir }}/kubelet/kubeconfig"
   log_dir: "{{ kubernetes_log_dir }}/kubelet"
   logtostderr: false
-  # max-pods: 40
   max-pods: 200
   node-status-update-frequency: 10s
   port: 10250
@@ -113,4 +109,6 @@ kubelet:
   v: 1
 logentries_token:
 logentries_url:
+master_port: "{{master_port}}"
 master_private_ip: 127.0.0.1
+master_scheme: "{{master_scheme}}"

--- a/hack/terraform-remote.sh
+++ b/hack/terraform-remote.sh
@@ -25,12 +25,12 @@ terraform remote config \
   -pull=true
 
 case $verb in
-  apply)
+  apply|plan)
     # terraform doesn't provide a first-class way to represent rendered template contents 
     # as a resource (see https://github.com/hashicorp/terraform/issues/2342), so we explicitly
     # taint before running apply so terraform will re-render the template
     terraform taint template_file.ansible_inventory
-    time terraform apply -input=false $@
+    time terraform $verb -input=false $@
     ;;
   destroy)
     time terraform destroy -input=false -force=true $@

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -216,7 +216,15 @@ resource "aws_security_group" "vpc_secgroup" {
     self        = true
   }
 
-  # icmp (with the default group)
+  # intra-group all ports / all protocols
+  ingress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    self            = true
+  }
+
+  # inbound all ports / all protocols from the vpc's default secgroup
   ingress {
     from_port       = 0
     to_port         = 0

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -150,7 +150,7 @@ resource "aws_security_group" "vpc_secgroup" {
   description = "Security group for ${var.aws_user_prefix}_${var.cluster_name} cluster"
   vpc_id      = "${aws_vpc.vpc.id}"
 
-  # ssh
+  # inbound ssh access from the world
   ingress {
     from_port   = 22
     to_port     = 22
@@ -158,7 +158,9 @@ resource "aws_security_group" "vpc_secgroup" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # http
+  # XXX: all of the ports below are hardcodes / copy-pasta from ansible/roles/kubernetes/defaults/main.yaml
+
+  # inbound kube-apiserver http access from the world
   ingress {
     from_port   = 8080
     to_port     = 8080
@@ -166,7 +168,7 @@ resource "aws_security_group" "vpc_secgroup" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # https
+  # inbound kube-apiserver https access from the world
   ingress {
     from_port   = 443
     to_port     = 443
@@ -174,7 +176,7 @@ resource "aws_security_group" "vpc_secgroup" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # non-embedded cadvisor
+  # inbound cadvisor access from the world
   ingress {
     from_port   = 8094
     to_port     = 8094
@@ -182,13 +184,38 @@ resource "aws_security_group" "vpc_secgroup" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # icmp (intra-group)
+  # intra-group kubelet http access
   ingress {
-    self      = true
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
+    from_port   = 10250
+    to_port     = 10250
+    protocol    = "TCP"
+    self        = true
   }
+
+  # intra-group kube-scheduler http access
+  ingress {
+    from_port   = 10251
+    to_port     = 10251
+    protocol    = "TCP"
+    self        = true
+  }
+
+  # intra-group kube-controller-manager http access
+  ingress {
+    from_port = 10252
+    to_port   = 10252
+    protocol  = "TCP"
+    self      = true
+  }
+
+  # intra-group kubelet/healthz http access
+  ingress {
+    from_port = 10254
+    to_port   = 10254
+    protocol  = "TCP"
+    self      = true
+  }
+
 
   # icmp (with the default group)
   ingress {

--- a/terraform/aws/templates/ansible.inventory.tpl
+++ b/terraform/aws/templates/ansible.inventory.tpl
@@ -12,22 +12,24 @@ localhost
 
 [local:vars]
 ansible_connection=local
-cluster_name=${cluster_name}
-cluster_master_record=${cluster_master_record}
 ansible_ssh_private_key_file=${ansible_ssh_private_key_file}
-etcd_public_ip=${etcd_public_ip}
-master_public_ip=${master_public_ip}
-kubernetes_cert_dir=${kubernetes_cert_dir}
+cluster_master_record=${cluster_master_record}
+cluster_name=${cluster_name}
 cluster_user=${cluster_user}
+etcd_public_ip=${etcd_public_ip}
+kubernetes_cert_dir=${kubernetes_cert_dir}
+master_public_ip=${master_public_ip}
 
 [cluster:vars]
 ansible_connection=ssh
 ansible_python_interpreter="PATH=/home/core/bin:$PATH python"
-ansible_ssh_user=core
 ansible_ssh_private_key_file=${ansible_ssh_private_key_file}
+ansible_ssh_user=core
+apiserver_ip_pool=${apiserver_ip_pool}
+apiserver_nginx_pool=${apiserver_nginx_pool}
 cluster_master_record=${cluster_master_record}
-cluster_proxy_record=${cluster_proxy_record}
 cluster_name=${cluster_name}
+cluster_proxy_record=${cluster_proxy_record}
 cluster_user=${cluster_user}
 dns_domain=${dns_domain}
 dns_ip=${dns_ip}
@@ -46,12 +48,10 @@ kubernetes_binaries_uri=${kubernetes_binaries_uri}
 kubernetes_cert_dir=${kubernetes_cert_dir}
 logentries_token=${logentries_token}
 logentries_url=${logentries_url}
+master_port="${master_port}""
 master_private_ip=${master_private_ip}
 master_public_ip=${master_public_ip}
-apiserver_nginx_pool=${apiserver_nginx_pool}
-apiserver_ip_pool=${apiserver_ip_pool}
 master_scheme=${master_scheme}
-master_port="${master_port}""
 
 [cluster:children]
 master

--- a/terraform/aws/templates/apiserver.yaml.tpl
+++ b/terraform/aws/templates/apiserver.yaml.tpl
@@ -10,8 +10,8 @@ write_files:
       [apiservers:vars]
       ansible_connection=ssh
       ansible_python_interpreter="PATH=/home/core/bin:$PATH python"
-      ansible_ssh_user=core
       ansible_ssh_private_key_file=/opt/ansible/private_key
+      ansible_ssh_user=core
       cluster_name=${cluster_name}
       cluster_user=${cluster_user}
       dns_domain=${dns_domain}
@@ -26,13 +26,13 @@ write_files:
       kraken_services_branch=${kraken_services_branch}
       kraken_services_dirs=${kraken_services_dirs}
       kraken_services_repo=${kraken_services_repo}
-      kubernetes_cert_dir=${kubernetes_cert_dir}
       kubernetes_api_version=${kubernetes_api_version}
       kubernetes_binaries_uri=${kubernetes_binaries_uri}
+      kubernetes_cert_dir=${kubernetes_cert_dir}
       logentries_token=${logentries_token}
       logentries_url=${logentries_url}
-      master_scheme=${master_scheme}
       master_port="${master_port}"
+      master_scheme=${master_scheme}
 coreos:
   etcd2:
     proxy: on

--- a/terraform/aws/templates/etcd.yaml.tpl
+++ b/terraform/aws/templates/etcd.yaml.tpl
@@ -10,8 +10,8 @@ write_files:
       [etcd:vars]
       ansible_connection=ssh
       ansible_python_interpreter="PATH=/home/core/bin:$PATH python"
-      ansible_ssh_user=core
       ansible_ssh_private_key_file=/opt/ansible/private_key
+      ansible_ssh_user=core
       kubernetes_binaries_uri=${kubernetes_binaries_uri}
       logentries_token=${logentries_token}
       logentries_url=${logentries_url}

--- a/terraform/aws/templates/master.yaml.tpl
+++ b/terraform/aws/templates/master.yaml.tpl
@@ -10,11 +10,13 @@ write_files:
       [master:vars]
       ansible_connection=ssh
       ansible_python_interpreter="PATH=/home/core/bin:$PATH python"
-      ansible_ssh_user=core
       ansible_ssh_private_key_file=/opt/ansible/private_key
+      ansible_ssh_user=core
+      apiserver_ip_pool=${apiserver_ip_pool}
+      apiserver_nginx_pool=${apiserver_nginx_pool}
       cluster_master_record=${cluster_master_record}
-      cluster_proxy_record=${cluster_proxy_record}
       cluster_name=${cluster_name}
+      cluster_proxy_record=${cluster_proxy_record}
       cluster_user=${cluster_user}
       dns_domain=${dns_domain}
       dns_ip=${dns_ip}
@@ -28,17 +30,15 @@ write_files:
       kraken_services_branch=${kraken_services_branch}
       kraken_services_dirs=${kraken_services_dirs}
       kraken_services_repo=${kraken_services_repo}
-      kubernetes_cert_dir=${kubernetes_cert_dir}
       kubernetes_api_version=${kubernetes_api_version}
       kubernetes_binaries_uri=${kubernetes_binaries_uri}
+      kubernetes_cert_dir=${kubernetes_cert_dir}
       logentries_token=${logentries_token}
       logentries_url=${logentries_url}
+      master_port="${master_port}"
       master_private_ip=$private_ipv4
       master_public_ip=$public_ipv4
-      apiserver_nginx_pool=${apiserver_nginx_pool}
-      apiserver_ip_pool=${apiserver_ip_pool}
       master_scheme=${master_scheme}
-      master_port="${master_port}"
 coreos:
   etcd2:
     proxy: on

--- a/terraform/aws/templates/node.yaml.tpl
+++ b/terraform/aws/templates/node.yaml.tpl
@@ -10,11 +10,11 @@ write_files:
       [nodes:vars]
       ansible_connection=ssh
       ansible_python_interpreter="PATH=/home/core/bin:$PATH python"
-      ansible_ssh_user=core
       ansible_ssh_private_key_file=/opt/ansible/private_key
+      ansible_ssh_user=core
       cluster_master_record=${cluster_master_record}
-      cluster_proxy_record=${cluster_proxy_record}
       cluster_name=${cluster_name}
+      cluster_proxy_record=${cluster_proxy_record}
       cluster_user=${cluster_user}
       dns_domain=${dns_domain}
       dns_ip=${dns_ip}
@@ -28,15 +28,15 @@ write_files:
       kraken_services_branch=${kraken_services_branch}
       kraken_services_dirs=${kraken_services_dirs}
       kraken_services_repo=${kraken_services_repo}
-      kubernetes_cert_dir=${kubernetes_cert_dir}
       kubernetes_api_version=${kubernetes_api_version}
       kubernetes_binaries_uri=${kubernetes_binaries_uri}
+      kubernetes_cert_dir=${kubernetes_cert_dir}
       logentries_token=${logentries_token}
       logentries_url=${logentries_url}
+      master_port="${master_port}"
       master_private_ip=${master_private_ip}
       master_public_ip=${master_public_ip}
       master_scheme=${master_scheme}
-      master_port="${master_port}"
 coreos:
   etcd2:
     proxy: on


### PR DESCRIPTION
We want prometheus, running as a pod, to be able to scrape /metrics
endpoints for the master components (controller-manager, scheduler)

The ideal way to do this would be for the components to expose themselves
or be deployed in such a way as to show up as pods/services.

In the meantime, bind to 0.0.0.0, and tighten up the secgroup a bi