### PR TITLE
KRAK-278 add selectable enable sysdig agent to cloudinit

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yaml
+++ b/ansible/roles/kubernetes/defaults/main.yaml
@@ -113,3 +113,4 @@ logentries_url:
 master_port: "{{master_port}}"
 master_private_ip: 127.0.0.1
 master_scheme: "{{master_scheme}}"
+sysdigcloud_access_key: "DISABLED"

--- a/ansible/roles/kubernetes/defaults/main.yaml
+++ b/ansible/roles/kubernetes/defaults/main.yaml
@@ -113,4 +113,4 @@ logentries_url:
 master_port: "{{master_port}}"
 master_private_ip: 127.0.0.1
 master_scheme: "{{master_scheme}}"
-sysdigcloud_access_key: "DISABLED"
+sysdigcloud_access_key: 

--- a/ansible/roles/kubernetes/handlers/main.yaml
+++ b/ansible/roles/kubernetes/handlers/main.yaml
@@ -26,6 +26,7 @@
   service: name=load-kube-cert state=restarted enabled=yes
   become: yes
 
+
 # master-common
 
 - name: restart nginx-docker
@@ -104,4 +105,10 @@
 
 - name: restart cadvisor
   service: name=cadvisor state=restarted enabled=yes
+  become: yes
+
+# sysdig-agent
+
+- name: restart sysdig-cloud-agent
+  service: name=sysdig-cloud-agent state=restarted enabled=yes
   become: yes

--- a/ansible/roles/kubernetes/tasks/main.yaml
+++ b/ansible/roles/kubernetes/tasks/main.yaml
@@ -2,6 +2,8 @@
 # Common tasks for every node
 - include: common.yaml
 
+- include: sysdig-cloud-agent.yaml
+
 - include: cadvisor.yaml
   when: "'master' in group_names or 'etcd' in group_names or 'apiservers' in group_names"
 

--- a/ansible/roles/kubernetes/tasks/sysdig-cloud-agent.yaml
+++ b/ansible/roles/kubernetes/tasks/sysdig-cloud-agent.yaml
@@ -1,0 +1,14 @@
+---
+- name: Create sysdig-cloud-agent
+  template: src=sysdig-cloud-agent.service.ansible
+            dest=/etc/systemd/system/sysdig-cloud-agent.service
+  become: yes
+  when: sysdigcloud_access_key|default("DISABLED") != "DISABLED"
+  notify:
+    - reload systemd
+    - restart sysdig-cloud-agent
+
+- name: Ensure sysdig-cloud-agent.service started
+  service: name=sysdig-cloud-agent state=started enabled=yes args=--no-block
+  when: sysdigcloud_access_key|default("DISABLED") != "DISABLED"
+  become: yes

--- a/ansible/roles/kubernetes/tasks/sysdig-cloud-agent.yaml
+++ b/ansible/roles/kubernetes/tasks/sysdig-cloud-agent.yaml
@@ -3,12 +3,12 @@
   template: src=sysdig-cloud-agent.service.ansible
             dest=/etc/systemd/system/sysdig-cloud-agent.service
   become: yes
-  when: sysdigcloud_access_key|default("DISABLED") != "DISABLED"
+  when: sysdigcloud_access_key|default("") != ""
   notify:
     - reload systemd
     - restart sysdig-cloud-agent
 
 - name: Ensure sysdig-cloud-agent.service started
   service: name=sysdig-cloud-agent state=started enabled=yes args=--no-block
-  when: sysdigcloud_access_key|default("DISABLED") != "DISABLED"
+  when: sysdigcloud_access_key|default("") != ""
   become: yes

--- a/ansible/roles/kubernetes/templates/sysdig-cloud-agent.service.ansible
+++ b/ansible/roles/kubernetes/templates/sysdig-cloud-agent.service.ansible
@@ -11,7 +11,17 @@ TimeoutStartSec=5
 ExecStartPre=-/usr/bin/docker kill sysdig-agent
 ExecStartPre=-/usr/bin/docker rm sysdig-agent
 ExecStartPre=/usr/bin/docker pull sysdig/agent
-ExecStart=/usr/bin/docker run --name sysdig-agent --privileged --net host --pid host -e ACCESS_KEY={{sysdigcloud_access_key}} -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro sysdig/agent
+ExecStart=/usr/bin/docker run \
+  --name sysdig-agent \
+  --privileged \
+  --net host \
+  --pid host \
+  -e ACCESS_KEY={{sysdigcloud_access_key}} \
+  -v /var/run/docker.sock:/host/var/run/docker.sock \
+  -v /dev:/host/dev \
+  -v /proc:/host/proc:ro \
+  -v /boot:/host/boot:ro \
+  sysdig/agent
 ExecStop=/usr/bin/docker stop sysdig-agent
 
 [X-Fleet]

--- a/ansible/roles/kubernetes/templates/sysdig-cloud-agent.service.ansible
+++ b/ansible/roles/kubernetes/templates/sysdig-cloud-agent.service.ansible
@@ -1,0 +1,18 @@
+[Unit]
+Description=Sysdig Cloud Agent
+Requires=docker.service
+After=docker.service 
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=5
+ExecStartPre=-/usr/bin/docker kill sysdig-agent
+ExecStartPre=-/usr/bin/docker rm sysdig-agent
+ExecStartPre=/usr/bin/docker pull sysdig/agent
+ExecStart=/usr/bin/docker run --name sysdig-agent --privileged --net host --pid host -e ACCESS_KEY={{sysdigcloud_access_key}} -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro sysdig/agent
+ExecStop=/usr/bin/docker stop sysdig-agent
+
+[X-Fleet]
+Global=true

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -276,6 +276,7 @@ resource "template_file" "etcd_cloudinit" {
     kubernetes_binaries_uri   = "${var.kubernetes_binaries_uri}"
     logentries_token          = "${var.logentries_token}"
     logentries_url            = "${var.logentries_url}"
+    sysdigcloud_access_key    = "${var.sysdigcloud_access_key}"
   }
 }
 
@@ -341,6 +342,7 @@ resource "template_file" "apiserver_cloudinit" {
     logentries_url            = "${var.logentries_url}"
     master_port               = "${var.master_port}"
     master_scheme             = "${var.master_scheme}"
+    sysdigcloud_access_key    = "${var.sysdigcloud_access_key}"
   }
 }
 
@@ -413,6 +415,7 @@ resource "template_file" "master_cloudinit" {
     master_port               = "${var.master_port}"
     master_scheme             = "${var.master_scheme}"
     short_name                = "master"
+    sysdigcloud_access_key    = "${var.sysdigcloud_access_key}"
   }
 }
 
@@ -486,6 +489,7 @@ resource "template_file" "node_cloudinit_special" {
     master_public_ip           = "${aws_instance.kubernetes_master.public_ip}"
     master_scheme              = "${var.master_scheme}"
     short_name                 = "node-${format("%03d", count.index+1)}"
+    sysdigcloud_access_key     = "${var.sysdigcloud_access_key}"
   }
 }
 
@@ -569,6 +573,7 @@ resource "template_file" "node_cloudinit" {
     master_public_ip            = "${aws_instance.kubernetes_master.public_ip}"
     master_scheme               = "${var.master_scheme}"
     short_name                  = "autoscaled"
+    sysdigcloud_access_key      = "${var.sysdigcloud_access_key}"
   }
 }
 
@@ -688,6 +693,7 @@ resource "template_file" "ansible_inventory" {
     master_public_ip              = "${aws_instance.kubernetes_master.public_ip}"
     master_scheme                 = "${var.master_scheme}"
     nodes_inventory_info          = "${join("\n", formatlist("%v ansible_ssh_host=%v", aws_instance.kubernetes_node_special.*.tags.ShortName, aws_instance.kubernetes_node_special.*.public_ip))}"
+    sysdigcloud_access_key        = "${var.sysdigcloud_access_key}"
   }
 
   provisioner "local-exec" {

--- a/terraform/aws/templates/ansible.inventory.tpl
+++ b/terraform/aws/templates/ansible.inventory.tpl
@@ -53,6 +53,7 @@ master_port="${master_port}""
 master_private_ip=${master_private_ip}
 master_public_ip=${master_public_ip}
 master_scheme=${master_scheme}
+sysdigcloud_access_key=${sysdigcloud_access_key}
 
 [cluster:children]
 master

--- a/terraform/aws/templates/apiserver.yaml.tpl
+++ b/terraform/aws/templates/apiserver.yaml.tpl
@@ -33,6 +33,7 @@ write_files:
       logentries_url=${logentries_url}
       master_port="${master_port}"
       master_scheme=${master_scheme}
+      sysdigcloud_access_key=${sysdigcloud_access_key}
 coreos:
   etcd2:
     proxy: on

--- a/terraform/aws/templates/etcd.yaml.tpl
+++ b/terraform/aws/templates/etcd.yaml.tpl
@@ -15,6 +15,7 @@ write_files:
       kubernetes_binaries_uri=${kubernetes_binaries_uri}
       logentries_token=${logentries_token}
       logentries_url=${logentries_url}
+      sysdigcloud_access_key=${sysdigcloud_access_key}
 coreos:
   etcd2:
     name: etcd

--- a/terraform/aws/templates/master.yaml.tpl
+++ b/terraform/aws/templates/master.yaml.tpl
@@ -40,6 +40,7 @@ write_files:
       master_private_ip=$private_ipv4
       master_public_ip=$public_ipv4
       master_scheme=${master_scheme}
+      sysdigcloud_access_key=${sysdigcloud_access_key}
 coreos:
   etcd2:
     proxy: on

--- a/terraform/aws/templates/node.yaml.tpl
+++ b/terraform/aws/templates/node.yaml.tpl
@@ -37,6 +37,7 @@ write_files:
       master_private_ip=${master_private_ip}
       master_public_ip=${master_public_ip}
       master_scheme=${master_scheme}
+      sysdigcloud_access_key=${sysdigcloud_access_key}
 coreos:
   etcd2:
     proxy: on

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -15,6 +15,11 @@ variable "aws_user_prefix" {
   description = "AWS resource prefix - all resources with names will be identified as <aws_user_prefix>_<cluster_name>_resource. Also used in kubectl --user"
 }
 
+variable "sysdigcloud_access_key" {
+  description = "Sysdig Cloud Access Key"
+  default = "DISABLED"
+}
+
 # variables with defaults
 variable "kubeconfig" {
   description = "Location of kubeconfig file used during kubectl invocations"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -17,7 +17,7 @@ variable "aws_user_prefix" {
 
 variable "sysdigcloud_access_key" {
   description = "Sysdig Cloud Access Key"
-  default = "DISABLED"
+  default = ""
 }
 
 # variables with defaults

--- a/terraform/local/Vagrantfile
+++ b/terraform/local/Vagrantfile
@@ -144,6 +144,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           cluster_name
           master_scheme
           master_port
+	  sysdigcloud_access_key
         ).map { |s| [s.to_sym, ENV["KRAKEN_#{s.upcase}"]] }
         kraken_env_vars = Hash[kraken_env_var_entries]
 

--- a/terraform/local/local.tf
+++ b/terraform/local/local.tf
@@ -20,6 +20,7 @@ resource "template_file" "etcd_cloudinit" {
     kraken_branch = "${var.kraken_repo.branch}"
     kraken_commit = "${var.kraken_repo.commit_sha}"
     ansible_docker_image = "${var.ansible_docker_image}"
+    sysdigcloud_access_key    = "${var.sysdigcloud_access_key}"
   }
 
   provisioner "local-exec" {
@@ -61,6 +62,7 @@ resource "template_file" "master_cloudinit" {
     master_scheme               = "${var.master_scheme}"
     master_port                 = "${var.master_port}"
     command_passwd              = "${var.command_passwd}"
+    sysdigcloud_access_key    = "${var.sysdigcloud_access_key}"
   }
 
   provisioner "local-exec" {
@@ -100,6 +102,7 @@ resource "template_file" "apiserver_cloudinit" {
     ansible_docker_image        = "${var.ansible_docker_image}"
     master_scheme               = "${var.master_scheme}"
     master_port                 = "${var.master_port}"
+    sysdigcloud_access_key    = "${var.sysdigcloud_access_key}"
   }
 
   provisioner "local-exec" {
@@ -138,6 +141,7 @@ resource "template_file" "node_cloudinit" {
     ansible_docker_image        = "${var.ansible_docker_image}"
     master_scheme               = "${var.master_scheme}"
     master_port                 = "${var.master_port}"
+    sysdigcloud_access_key      = "${var.sysdigcloud_access_key}"
   }
 
   provisioner "local-exec" {
@@ -148,10 +152,10 @@ resource "template_file" "node_cloudinit" {
 resource "execute_command" "command" {
   depends_on      = ["template_file.node_cloudinit", "template_file.master_cloudinit", "template_file.etcd_cloudinit", "template_file.apiserver_cloudinit"]
   command         = "echo Running vagrant ..."
-  destroy_command = "KRAKEN_IP_BASE=${var.ip_base} KRAKEN_COREOS_CHANNEL=${var.coreos_update_channel} KRAKEN_COREOS_RELEASE=${coreosbox_vagrant.coreos_version_info.version_out} KRAKEN_NUMBER_APISERVERS=${var.apiserver_count} KRAKEN_NUMBER_NODES=${var.node_count} VAGRANT_CWD=${path.module} VAGRANT_DOTFILE_PATH=${path.module} KRAKEN_ETCD_CPUS=${var.etcd_cpus} KRAKEN_ETCD_MEM=${var.etcd_mem} KRAKEN_MASTER_CPUS=${var.master_cpus} KRAKEN_MASTER_MEM=${var.master_mem} KRAKEN_APISERVER_CPUS=${var.apiserver_cpus} KRAKEN_APISERVER_MEM=${var.apiserver_mem} KRAKEN_NODE_CPUS=${var.node_cpus} KRAKEN_NODE_MEM=${var.node_mem} KRAKEN_KRAKEN_SERVICES_REPO=${var.kraken_services_repo} KRAKEN_NODE_MEMEN_KRAKEN_SERVICES_BRANCH=${var.kraken_services_branch} KRAKEN_DNS_DOMAIN=${var.dns_domain} KRAKEN_DNS_IP=${var.dns_ip} KRAKEN_DOCKERCFG_BASE64='${var.dockercfg_base64}' KRAKEN_HYPERKUBE_DEPLOYMENT_MODE=${var.hyperkube_deployment_mode} KRAKEN_HYPERKUBE_IMAGE=${var.hyperkube_image} KRAKEN_KUBERNETES_BINARIES_URI=${var.kubernetes_binaries_uri} KRAKEN_KUBERNETES_API_VERSION=${var.kubernetes_api_version} KRAKEN_KRAKEN_SERVICES_DIRS='${var.kraken_services_dirs}' KRAKEN_LOGENTRIES_TOKEN=${var.logentries_token} KRAKEN_LOGENTRIES_URL=${var.logentries_url} KRAKEN_VAGRANT_PRIVATE_KEY=${var.vagrant_private_key} KRAKEN_INTERFACE_NAME=eth1 KRAKEN_CLUSTER_USER=${var.local_user_prefix} KRAKEN_CLUSTER_NAME=${var.cluster_name} KRAKEN_MASTER_SCHEME=${var.master_scheme} KRAKEN_master_port=${var.master_port} KRAKEN_KRAKEN_LOCAL_DIR=${var.kraken_local_dir} KRAKEN_KUBERNETES_CERT_DIR=${var.kubernetes_cert_dir} KRAKEN_COMMAND_PASSWD=${var.command_passwd} vagrant destroy --force"
+  destroy_command = "KRAKEN_IP_BASE=${var.ip_base} KRAKEN_COREOS_CHANNEL=${var.coreos_update_channel} KRAKEN_COREOS_RELEASE=${coreosbox_vagrant.coreos_version_info.version_out} KRAKEN_NUMBER_APISERVERS=${var.apiserver_count} KRAKEN_NUMBER_NODES=${var.node_count} VAGRANT_CWD=${path.module} VAGRANT_DOTFILE_PATH=${path.module} KRAKEN_ETCD_CPUS=${var.etcd_cpus} KRAKEN_ETCD_MEM=${var.etcd_mem} KRAKEN_MASTER_CPUS=${var.master_cpus} KRAKEN_MASTER_MEM=${var.master_mem} KRAKEN_APISERVER_CPUS=${var.apiserver_cpus} KRAKEN_APISERVER_MEM=${var.apiserver_mem} KRAKEN_NODE_CPUS=${var.node_cpus} KRAKEN_NODE_MEM=${var.node_mem} KRAKEN_KRAKEN_SERVICES_REPO=${var.kraken_services_repo} KRAKEN_NODE_MEMEN_KRAKEN_SERVICES_BRANCH=${var.kraken_services_branch} KRAKEN_DNS_DOMAIN=${var.dns_domain} KRAKEN_DNS_IP=${var.dns_ip} KRAKEN_DOCKERCFG_BASE64='${var.dockercfg_base64}' KRAKEN_HYPERKUBE_DEPLOYMENT_MODE=${var.hyperkube_deployment_mode} KRAKEN_HYPERKUBE_IMAGE=${var.hyperkube_image} KRAKEN_KUBERNETES_BINARIES_URI=${var.kubernetes_binaries_uri} KRAKEN_KUBERNETES_API_VERSION=${var.kubernetes_api_version} KRAKEN_KRAKEN_SERVICES_DIRS='${var.kraken_services_dirs}' KRAKEN_LOGENTRIES_TOKEN=${var.logentries_token} KRAKEN_LOGENTRIES_URL=${var.logentries_url} KRAKEN_VAGRANT_PRIVATE_KEY=${var.vagrant_private_key} KRAKEN_INTERFACE_NAME=eth1 KRAKEN_CLUSTER_USER=${var.local_user_prefix} KRAKEN_CLUSTER_NAME=${var.cluster_name} KRAKEN_MASTER_SCHEME=${var.master_scheme} KRAKEN_master_port=${var.master_port} KRAKEN_KRAKEN_LOCAL_DIR=${var.kraken_local_dir} KRAKEN_KUBERNETES_CERT_DIR=${var.kubernetes_cert_dir} KRAKEN_COMMAND_PASSWD=${var.command_passwd} SYSDIGCLOUD_ACCESS_KEY=${var.sysdigcloud_access_key} vagrant destroy --force"
 
   provisioner "local-exec" {
-    command = "KRAKEN_IP_BASE=${var.ip_base} KRAKEN_COREOS_CHANNEL=${var.coreos_update_channel} KRAKEN_COREOS_RELEASE=${coreosbox_vagrant.coreos_version_info.version_out} KRAKEN_NUMBER_APISERVERS=${var.apiserver_count} KRAKEN_NUMBER_NODES=${var.node_count} VAGRANT_CWD=${path.module} VAGRANT_DOTFILE_PATH=${path.module} KRAKEN_ETCD_CPUS=${var.etcd_cpus} KRAKEN_ETCD_MEM=${var.etcd_mem} KRAKEN_MASTER_CPUS=${var.master_cpus} KRAKEN_MASTER_MEM=${var.master_mem} KRAKEN_APISERVER_CPUS=${var.apiserver_cpus} KRAKEN_APISERVER_MEM=${var.apiserver_mem} KRAKEN_NODE_CPUS=${var.node_cpus} KRAKEN_NODE_MEM=${var.node_mem} KRAKEN_KRAKEN_SERVICES_REPO=${var.kraken_services_repo} KRAKEN_KRAKEN_SERVICES_BRANCH=${var.kraken_services_branch} KRAKEN_DNS_DOMAIN=${var.dns_domain} KRAKEN_DNS_IP=${var.dns_ip} KRAKEN_DOCKERCFG_BASE64='${var.dockercfg_base64}' KRAKEN_HYPERKUBE_DEPLOYMENT_MODE=${var.hyperkube_deployment_mode} KRAKEN_HYPERKUBE_IMAGE=${var.hyperkube_image} KRAKEN_KUBERNETES_BINARIES_URI=${var.kubernetes_binaries_uri} KRAKEN_KUBERNETES_API_VERSION=${var.kubernetes_api_version} KRAKEN_KRAKEN_SERVICES_DIRS='${var.kraken_services_dirs}' KRAKEN_LOGENTRIES_TOKEN=${var.logentries_token} KRAKEN_LOGENTRIES_URL=${var.logentries_url} KRAKEN_VAGRANT_PRIVATE_KEY=${var.vagrant_private_key} KRAKEN_INTERFACE_NAME=eth1 KRAKEN_CLUSTER_USER=${var.local_user_prefix} KRAKEN_CLUSTER_NAME=${var.cluster_name} KRAKEN_MASTER_SCHEME=${var.master_scheme} KRAKEN_master_port=${var.master_port} KRAKEN_KRAKEN_LOCAL_DIR=${var.kraken_local_dir} KRAKEN_KUBERNETES_CERT_DIR=${var.kubernetes_cert_dir} KRAKEN_COMMAND_PASSWD=${var.command_passwd} vagrant up"
+    command = "KRAKEN_IP_BASE=${var.ip_base} KRAKEN_COREOS_CHANNEL=${var.coreos_update_channel} KRAKEN_COREOS_RELEASE=${coreosbox_vagrant.coreos_version_info.version_out} KRAKEN_NUMBER_APISERVERS=${var.apiserver_count} KRAKEN_NUMBER_NODES=${var.node_count} VAGRANT_CWD=${path.module} VAGRANT_DOTFILE_PATH=${path.module} KRAKEN_ETCD_CPUS=${var.etcd_cpus} KRAKEN_ETCD_MEM=${var.etcd_mem} KRAKEN_MASTER_CPUS=${var.master_cpus} KRAKEN_MASTER_MEM=${var.master_mem} KRAKEN_APISERVER_CPUS=${var.apiserver_cpus} KRAKEN_APISERVER_MEM=${var.apiserver_mem} KRAKEN_NODE_CPUS=${var.node_cpus} KRAKEN_NODE_MEM=${var.node_mem} KRAKEN_KRAKEN_SERVICES_REPO=${var.kraken_services_repo} KRAKEN_KRAKEN_SERVICES_BRANCH=${var.kraken_services_branch} KRAKEN_DNS_DOMAIN=${var.dns_domain} KRAKEN_DNS_IP=${var.dns_ip} KRAKEN_DOCKERCFG_BASE64='${var.dockercfg_base64}' KRAKEN_HYPERKUBE_DEPLOYMENT_MODE=${var.hyperkube_deployment_mode} KRAKEN_HYPERKUBE_IMAGE=${var.hyperkube_image} KRAKEN_KUBERNETES_BINARIES_URI=${var.kubernetes_binaries_uri} KRAKEN_KUBERNETES_API_VERSION=${var.kubernetes_api_version} KRAKEN_KRAKEN_SERVICES_DIRS='${var.kraken_services_dirs}' KRAKEN_LOGENTRIES_TOKEN=${var.logentries_token} KRAKEN_LOGENTRIES_URL=${var.logentries_url} KRAKEN_VAGRANT_PRIVATE_KEY=${var.vagrant_private_key} KRAKEN_INTERFACE_NAME=eth1 KRAKEN_CLUSTER_USER=${var.local_user_prefix} KRAKEN_CLUSTER_NAME=${var.cluster_name} KRAKEN_MASTER_SCHEME=${var.master_scheme} KRAKEN_master_port=${var.master_port} KRAKEN_KRAKEN_LOCAL_DIR=${var.kraken_local_dir} KRAKEN_KUBERNETES_CERT_DIR=${var.kubernetes_cert_dir} KRAKEN_COMMAND_PASSWD=${var.command_passwd} SYSDIGCLOUD_ACCESS_KEY=${var.sysdigcloud_access_key} vagrant up"
   }
 
   provisioner "local-exec" {

--- a/terraform/local/templates/ansible.inventory.erb
+++ b/terraform/local/templates/ansible.inventory.erb
@@ -56,6 +56,7 @@ apiserver_nginx_pool=<%= apiserver_nginx_pool %>
 cluster_user=<%= cluster_user %>
 master_scheme=<%= master_scheme %>
 master_port="<%= master_port %>"
+sysdigcloud_access_key=<%= sysdigcloud_access_key %>
 
 [local:vars]
 ansible_connection=local

--- a/terraform/local/templates/apiserver.yaml.tpl
+++ b/terraform/local/templates/apiserver.yaml.tpl
@@ -32,6 +32,7 @@ write_files:
       logentries_url=${logentries_url}
       master_port="${master_port}"
       master_scheme=${master_scheme}
+      sysdigcloud_access_key=${sysdigcloud_access_key}
 coreos:
   etcd2:
     proxy: on

--- a/terraform/local/templates/etcd.yaml.tpl
+++ b/terraform/local/templates/etcd.yaml.tpl
@@ -15,6 +15,7 @@ write_files:
       kubernetes_binaries_uri=${kubernetes_binaries_uri}
       logentries_token=${logentries_token}
       logentries_url=${logentries_url}
+      sysdigcloud_access_key=${sysdigcloud_access_key}
 coreos:
   etcd2:
     name: etcd

--- a/terraform/local/templates/master.yaml.tpl
+++ b/terraform/local/templates/master.yaml.tpl
@@ -39,6 +39,7 @@ write_files:
       master_private_ip=$private_ipv4
       master_public_ip=$public_ipv4
       master_scheme=${master_scheme}
+      sysdigcloud_access_key=${sysdigcloud_access_key}
 
 coreos:
   etcd2:

--- a/terraform/local/templates/node.yaml.tpl
+++ b/terraform/local/templates/node.yaml.tpl
@@ -35,6 +35,7 @@ write_files:
       master_port="${master_port}"
       master_private_ip=$MASTER_PRIVATE_IP
       master_scheme=${master_scheme}
+      sysdigcloud_access_key=${sysdigcloud_access_key}
 coreos:
   etcd2:
     proxy: on

--- a/terraform/local/variables.tf
+++ b/terraform/local/variables.tf
@@ -7,6 +7,11 @@ variable "local_user_prefix" {
   default     = "vagrant"
 }
 
+variable "sysdigcloud_access_key" {
+  description = "Sysdig Cloud Access Key"
+  default = "DISABLED"
+}
+
 variable "kubeconfig" {
   description = "Location of kubeconfig file used during kubectl invocations"
   default     = "~/.kube/config"

--- a/terraform/local/variables.tf
+++ b/terraform/local/variables.tf
@@ -9,7 +9,7 @@ variable "local_user_prefix" {
 
 variable "sysdigcloud_access_key" {
   description = "Sysdig Cloud Access Key"
-  default = "DISABLED"
+  default = ""
 }
 
 variable "kubeconfig" {


### PR DESCRIPTION
KRAK-278  Add sysdig cloud agent in ansible such that if a sysdig key is present the service is included and started.  Else, the service is not included.