### PR TITLE
Krak 277

### DIFF
--- a/bin/kraken-connect.sh
+++ b/bin/kraken-connect.sh
@@ -36,7 +36,7 @@ if [ ${is_running} == "true" ];  then
   )
 fi
 
-target_cluster_dir="$(cd $(dirname ${KRAKEN_ROOT}/bin); pwd)/clusters/${KRAKEN_CLUSTER_NAME}" 
+target_cluster_dir="$(cd $(dirname ${KRAKEN_ROOT}); pwd)/bin/clusters/${KRAKEN_CLUSTER_NAME}" 
 mkdir -p "${target_cluster_dir}"
 
 for containerfile in "${containerfiles[@]}"; do

--- a/bin/kraken-connect.sh
+++ b/bin/kraken-connect.sh
@@ -36,7 +36,7 @@ if [ ${is_running} == "true" ];  then
   )
 fi
 
-target_cluster_dir="$(cd $(dirname ${KRAKEN_ROOT}); pwd)/bin/clusters/${KRAKEN_CLUSTER_NAME}" 
+target_cluster_dir="$(cd $(dirname ${KRAKEN_ROOT}); pwd)/clusters/${KRAKEN_CLUSTER_NAME}" 
 mkdir -p "${target_cluster_dir}"
 
 for containerfile in "${containerfiles[@]}"; do

--- a/bin/kraken-connect.sh
+++ b/bin/kraken-connect.sh
@@ -4,9 +4,9 @@
 #author          :Samsung SDSRA
 #==============================================================================
 
-#set -o errexit
-#set -o nounset
-#set -o pipefail
+set -o errexit
+set -o nounset
+set -o pipefail
 
 # kraken root folder
 KRAKEN_ROOT=$(dirname "${BASH_SOURCE}")/..
@@ -46,7 +46,6 @@ done
 if [ ${is_running} == "true" ];  then
   inf "Parameters for ssh:\n   \
     ssh -i ${target_cluster_dir}/id_rsa <node ip address>\n"
-
   exit 0
 fi
 

--- a/bin/kraken-connect.sh
+++ b/bin/kraken-connect.sh
@@ -36,7 +36,7 @@ if [ ${is_running} == "true" ];  then
   )
 fi
 
-target_cluster_dir=$(cd $(dirname ${KRAKEN_ROOT}/bin/clusters/${KRAKEN_CLUSTER_NAME}); pwd) 
+target_cluster_dir="$(cd $(dirname ${KRAKEN_ROOT}/bin); pwd)/clusters/${KRAKEN_CLUSTER_NAME}" 
 mkdir -p "${target_cluster_dir}"
 
 for containerfile in "${containerfiles[@]}"; do

--- a/bin/kraken-connect.sh
+++ b/bin/kraken-connect.sh
@@ -28,7 +28,7 @@ containerfiles=(
 is_running=$(docker inspect -f '{{ .State.Running }}' ${kraken_container_name})
 if [ ${is_running} == "true" ];  then
   warn "Cluster build is currently running. Will only copy SSH keys.\n Run\n  \
-    'docker logs --follow ${kraken_container_name}'\n to current log."
+    'docker logs --follow ${kraken_container_name}'\n to see the current log."
   
   containerfiles=(
     ${kraken_container_name}:/root/.ssh/id_rsa
@@ -36,7 +36,7 @@ if [ ${is_running} == "true" ];  then
   )
 fi
 
-target_cluster_dir="${KRAKEN_ROOT}/bin/clusters/${KRAKEN_CLUSTER_NAME}"
+target_cluster_dir=$(cd $(dirname ${KRAKEN_ROOT}/bin/clusters/${KRAKEN_CLUSTER_NAME}); pwd) 
 mkdir -p "${target_cluster_dir}"
 
 for containerfile in "${containerfiles[@]}"; do


### PR DESCRIPTION
allow for copying down of ssh keys even if build container is still running.
convert relative path in banner printout to absolute