### PR TITLE
Reduce Brewfile to minimal dependencies

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,10 +1,14 @@
-brew 'ansible'
-cask 'vagrant'
-brew 'kubernetes-cli'
-brew 'awscli'
+# homebrew addons
+tap 'homebrew/bundle'
+tap 'homebrew/cask'
+
+# to use docker
 cask 'virtualbox'
-tap 'Samsung-AG/terraform-provider-execute'
-tap 'Samsung-AG/terraform-provider-coreosbox'
-brew 'terraform'
-brew 'terraform-provider-execute'
-brew 'terraform-provider-coreosbox'
+brew 'docker-machine'
+brew 'docker'
+
+# to interact with the cluster
+brew 'kubernetes-cli'
+
+# for 'local' clustertypes
+cask 'vagrant'


### PR DESCRIPTION
To discourage the use of ansible and terraform outside of the
samsung_ag/kraken container, let's remove them from the Brewfile