### PR TITLE
Change default cluster name to satisfy conformance DNS test

### DIFF
--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -303,7 +303,7 @@ variable "ansible_docker_image" {
 }
 
 variable "dns_domain" {
-  default     = "kubernetes.local"
+  default     = "cluster.local"
   description = "Kubenretes DNS domain"
 }
 

--- a/terraform/local/variables.tf
+++ b/terraform/local/variables.tf
@@ -93,7 +93,7 @@ variable "node_mem" {
 }
 
 variable "dns_domain" {
-  default     = "kubernetes.local"
+  default     = "cluster.local"
   description = "Kubenretes DNS domain"
 }
 


### PR DESCRIPTION
Small change to dns_domain from 'kubernetes.local' to 'cluster.local' to satisfy dns.go test https://github.com/kubernetes/kubernetes/blob/release-1.2/test/e2e/dns.go

