### PR TITLE
Prepend `time` invocation to terraform

### DIFF
--- a/bin/build/terraform-down.sh
+++ b/bin/build/terraform-down.sh
@@ -21,7 +21,7 @@ if [ -z ${KRAKEN_CLUSTER_NAME+x} ]; then
 fi
 
 max_retries=10
-until terraform destroy -force -input=false \
+time until terraform destroy -force -input=false \
   -var-file=/opt/kraken/terraform/${KRAKEN_CLUSTER_TYPE}/${KRAKEN_CLUSTER_NAME}/terraform.tfvars \
   -state=/kraken_data/${KRAKEN_CLUSTER_NAME}/terraform.tfstate \
   -var 'cluster_name=${KRAKEN_CLUSTER_NAME}' /opt/kraken/terraform/${KRAKEN_CLUSTER_TYPE}

--- a/bin/build/terraform-up.sh
+++ b/bin/build/terraform-up.sh
@@ -21,7 +21,7 @@ if [ -z ${KRAKEN_CLUSTER_NAME+x} ]; then
 fi
 
 mkdir -p "/kraken_data/${KRAKEN_CLUSTER_NAME}/group_vars"
-terraform apply \
+time terraform apply \
   -input=false \
   -state=/kraken_data/${KRAKEN_CLUSTER_NAME}/terraform.tfstate \
   -var-file=/opt/kraken/terraform/${KRAKEN_CLUSTER_TYPE}/${KRAKEN_CLUSTER_NAME}/terraform.tfvars \


### PR DESCRIPTION
I could do it on my own but if we've already got terraform dumping
some output about how many resources changed, why not include how
long it took to change those resources