### PR TITLE
Clean-up package installation, remove dependencies that are auto-installed, prefer pip

### DIFF
--- a/bin/build/Dockerfile
+++ b/bin/build/Dockerfile
@@ -10,21 +10,14 @@ ENV ANSIBLE_VERSION 2.0.0.2
 ENV AWSCLI_VERSION 1.10.4
 
 # python and ansible
-# TODO: install python dependencies via pip isntead of apt
 RUN apt-get update \
     && apt-get install -y --force-yes \
       curl \
       unzip \
       jq \
-      build-essential \
-      python-yaml \
-      python-jinja2 \
-      python-httplib2 \
-      python-keyczar \
-      python-paramiko \
-      python-setuptools \
-      python-pkg-resources \
       python-pip \
+      python-dev \
+      python-yaml \
       openssh-client \
       vim \
     && mkdir /etc/ansible/ \


### PR DESCRIPTION
1. Removed chained dependencies so that the primary packages will pull the proper (version) dependencies as the primary packages are versioned forward.

2. Added python-dev which is _not_ part of python-pip and is usually what breaks pip installs (or the dependency packages).

3. left python-yaml as  #an APT package because:
    a) libyaml-dev would be needed to install pip's pyyaml package
    b) installing pip's pyyaml package has a ton of compiler warnings (bad juju IMO)